### PR TITLE
fix: Corriger l'alignement des jours du calendrier pour le format fra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- **[Frontend]** Calendrier de navigation - Correction de l'alignement des jours pour le calendrier français
+  - Les jours sont maintenant correctement alignés avec lundi en première colonne (L, M, M, J, V, S, D)
+  - Fix: `getDay()` retourne 0 pour dimanche, ajout de transformation modulo `(getDay() + 6) % 7`
+  - Exemple: 4 septembre 2025 (jeudi) s'affiche maintenant dans la colonne jeudi et non vendredi
+  - Fichier: `apps/web/src/pages/Consumption/components/DetailedLoadCurve.tsx`
+
+### Improved
+- **[Frontend]** Navigation par jour dans la courbe de charge détaillée
+  - Boutons de jour affichés sur 2 lignes : date complète (ex: "lun. 17 nov") + puissance (ex: "12.45 kWh")
+  - Nombre de jours visibles calculé dynamiquement avec hook `useResponsiveDayCount`
+  - Ajustement automatique selon la largeur du conteneur (min 3 jours, max 14 jours)
+  - Fichier: `apps/web/src/pages/Consumption/hooks/useResponsiveDayCount.ts`
+
+- **[Frontend]** Sélection de date intelligente dans le calendrier
+  - Lorsqu'une date nécessite le chargement d'une nouvelle semaine, l'utilisateur arrive maintenant sur la date sélectionnée (et non la première date)
+  - Implémentation d'un état `pendingDateSelection` pour mémoriser la date cliquée pendant le chargement
+  - Navigation automatique vers le bon jour une fois les données chargées
+
+- **[Frontend]** Comparaisons semaine -1 et année -1
+  - Extraction automatique des données de comparaison depuis le cache React Query
+  - Parcours intelligent des queries en cache pour trouver les données par filtrage de date
+  - Support du format batch avec filtrage sur `interval_reading` array
+  - Boutons de comparaison toujours actifs (suppression des checks de disponibilité restrictifs)

--- a/apps/web/src/pages/Consumption/hooks/useResponsiveDayCount.ts
+++ b/apps/web/src/pages/Consumption/hooks/useResponsiveDayCount.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, RefObject } from 'react'
+
+/**
+ * Hook to calculate the optimal number of days to display in the carousel
+ * based on available container width to avoid truncated day labels
+ *
+ * @param containerRef - Reference to the carousel container element
+ * @param minDayWidth - Minimum width per day button in pixels (default: 120px)
+ * @param maxDays - Maximum number of days to show (default: 14)
+ * @returns Number of days that can fit without truncation
+ */
+export function useResponsiveDayCount(
+  containerRef: RefObject<HTMLDivElement>,
+  minDayWidth: number = 120,
+  maxDays: number = 14
+): number {
+  const [visibleDays, setVisibleDays] = useState(7) // Default: 7 days
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const calculateVisibleDays = () => {
+      if (!containerRef.current) return
+
+      // Get container width
+      const containerWidth = containerRef.current.offsetWidth
+
+      // Account for navigation buttons (2 × 40px) + gaps (multiple × 8px)
+      const navigationWidth = 80 // Left + right navigation buttons
+      const gapWidth = 16 // Total gap space (2 × 8px for each side)
+      const exportButtonWidth = 160 // Export JSON button approximate width
+
+      // Available width for day buttons
+      const availableWidth = containerWidth - navigationWidth - gapWidth - exportButtonWidth
+
+      // Calculate how many days can fit
+      const calculatedDays = Math.floor(availableWidth / minDayWidth)
+
+      // Clamp between 3 and maxDays
+      const finalDays = Math.max(3, Math.min(maxDays, calculatedDays))
+
+      setVisibleDays(finalDays)
+    }
+
+    // Calculate on mount
+    calculateVisibleDays()
+
+    // Recalculate on window resize
+    const resizeObserver = new ResizeObserver(calculateVisibleDays)
+    resizeObserver.observe(containerRef.current)
+
+    // Cleanup
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [containerRef, minDayWidth, maxDays])
+
+  return visibleDays
+}

--- a/docs/pages/consumption.md
+++ b/docs/pages/consumption.md
@@ -117,12 +117,18 @@ Page permettant aux utilisateurs de **visualiser et analyser leur consommation �
 
 - ✅ Afficher la courbe des données par intervalle transmis par Enedis
 - ✅ Proposer une navigation par semaine et par jour (onglets de 7 jours) avec des contrôles gauche/droite pour parcourir les semaines
+  - Boutons de jour adaptatifs : affichage sur 2 lignes (date complète + puissance)
+  - Responsive : nombre de jours visible calculé dynamiquement selon la largeur d'écran
 - ✅ **Calendrier** respectant le CSS du site et empêchant la navigation en dehors des plages présentes en cache
+  - Alignement des jours corrigé pour calendrier français (lundi en première colonne)
+  - Sélection de date intelligente : navigation vers la bonne semaine puis sélection automatique du jour
 - ✅ **Trois raccourcis** au même niveau que le calendrier pour naviguer rapidement :
   - Aujourd'hui
   - Semaine dernière
   - Il y a un an
 - ✅ Comparer avec l'année et la semaine précédentes lorsqu'elles sont disponibles
+  - Chargement automatique depuis le cache React Query (batch data)
+  - Extraction intelligente des données de comparaison par filtrage de date
 - ✅ Export JSON disponible
 
 #### 4.2 Consommation HC/HP par mois ✅


### PR DESCRIPTION
…nçais

Correction de l'offset des jours dans le calendrier de navigation de la courbe de charge détaillée. Le calendrier affiche maintenant correctement les jours alignés sur le format français (L-D) au lieu du format US (D-S).

Problème:
- getDay() retourne 0 pour dimanche, mais le calendrier français commence par lundi
- Exemple: 4 septembre 2025 (jeudi) s'affichait dans la colonne vendredi (décalage de 1 jour)

Solution:
- Ajout de transformation modulo: (getDay() + 6) % 7
- Conversion: Dimanche(0)→6, Lundi(1)→0, Mardi(2)→1, etc.
- Alignement correct avec les en-têtes de colonne [L, M, M, J, V, S, D]

Améliorations supplémentaires:
- Boutons de jour sur 2 lignes (date + puissance) pour meilleure lisibilité
- Hook useResponsiveDayCount pour calcul dynamique du nombre de jours visibles
- Sélection de date intelligente avec état pendingDateSelection
- Comparaisons semaine/année avec extraction depuis cache React Query
- Documentation mise à jour (consumption.md + CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)