### PR TITLE
feat: add unified PDL selector header to Dashboard, Tempo, Ecowatt, a…

### DIFF
--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
-import { TrendingUp, Sun, Calculator, Download, Lock } from 'lucide-react'
+import { TrendingUp, Sun, Calculator, Download, Lock, LayoutDashboard, Calendar, Zap, Users } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { pdlApi } from '@/api/pdl'
 import { usePdlStore } from '@/stores/pdlStore'
@@ -10,15 +10,18 @@ import { useUnifiedDataFetch } from '@/hooks/useUnifiedDataFetch'
 import { LoadingStatusBadge } from './LoadingStatusBadge'
 import type { PDL } from '@/types/api'
 
-// Pages qui affichent le sélecteur de PDL
-const PDL_SELECTOR_PAGES = ['/consumption', '/production', '/simulator']
+// Pages qui affichent le sélecteur de PDL avec bouton "Récupérer"
+const PDL_SELECTOR_PAGES = ['/consumption', '/production', '/simulator', '/dashboard', '/tempo', '/ecowatt', '/contribute']
 
 // Configuration des titres et icônes par page
 const PAGE_CONFIG: Record<string, { title: string; icon: typeof TrendingUp; subtitle?: string }> = {
-  '/dashboard': { title: 'Tableau de bord', icon: TrendingUp },
+  '/dashboard': { title: 'Tableau de bord', icon: LayoutDashboard, subtitle: 'Gérez vos points de livraison' },
   '/consumption': { title: 'Consommation', icon: TrendingUp, subtitle: 'Visualisez et analysez votre consommation électrique' },
   '/production': { title: 'Production', icon: Sun, subtitle: 'Visualisez et analysez votre production d\'énergie solaire' },
   '/simulator': { title: 'Comparateur des abonnements', icon: Calculator, subtitle: 'Comparez automatiquement le coût de toutes les offres disponibles' },
+  '/tempo': { title: 'Calendrier Tempo', icon: Calendar, subtitle: 'Historique des jours Tempo bleus, blancs et rouges fourni par RTE' },
+  '/ecowatt': { title: 'EcoWatt - Signal RTE', icon: Zap, subtitle: 'Suivez en temps réel l\'état du réseau électrique français' },
+  '/contribute': { title: 'Contribuer à la base de données', icon: Users, subtitle: 'Aidez la communauté en ajoutant des offres tarifaires' },
 }
 
 export default function PageHeader() {
@@ -42,10 +45,8 @@ export default function PageHeader() {
   const pdls: PDL[] = Array.isArray(pdlsResponse) ? pdlsResponse : []
   const selectedPDLDetails = pdls.find(p => p.usage_point_id === selectedPdl)
 
-  // Determine page context for data fetching
-  const pageContext = location.pathname === '/production' ? 'production' as const
-    : location.pathname === '/consumption' ? 'consumption' as const
-    : 'all' as const
+  // Toujours récupérer toutes les données (consommation + production), quelle que soit la page
+  const pageContext = 'all' as const
 
   // Hook unifié pour récupérer toutes les données
   const { fetchAllData } = useUnifiedDataFetch({

--- a/apps/web/src/pages/Contribute.tsx
+++ b/apps/web/src/pages/Contribute.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Users, CheckCircle, Clock, XCircle, List, Zap, Upload, FileJson } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, List, Zap, Upload, FileJson } from 'lucide-react'
 import { energyApi, type EnergyProvider, type ContributionData, type EnergyOffer } from '@/api/energy'
 
 export default function Contribute() {
@@ -310,17 +310,7 @@ export default function Contribute() {
         </div>
       )}
 
-      <div className="mb-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
-            <Users className="text-primary-600 dark:text-primary-400" size={32} />
-            Contribuer à la base de données
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400">
-            Aidez la communauté en ajoutant ou mettant à jour les offres tarifaires des fournisseurs d'énergie.
-            Les administrateurs vérifieront votre contribution avant publication.
-          </p>
-        </div>
+      <div className="mb-6 flex flex-col sm:flex-row items-start sm:items-center justify-end gap-4">
         <button
           onClick={() => setShowJsonImport(!showJsonImport)}
           className="btn btn-secondary flex items-center gap-2 whitespace-nowrap"

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useSearchParams, Link } from 'react-router-dom'
 import { pdlApi } from '@/api/pdl'
 import { oauthApi } from '@/api/oauth'
 import { logger } from '@/utils/logger'
-import { ExternalLink, CheckCircle, XCircle, ArrowUpDown, GripVertical, UserPlus, Filter, Search, Keyboard, X as CloseIcon, AlertCircle, LayoutDashboard } from 'lucide-react'
+import { ExternalLink, CheckCircle, XCircle, ArrowUpDown, GripVertical, UserPlus, Filter, Search, Keyboard, X as CloseIcon, AlertCircle } from 'lucide-react'
 import PDLDetails from '@/components/PDLDetails'
 import PDLCard from '@/components/PDLCard'
 import { PDLCardSkeleton } from '@/components/Skeleton'
@@ -631,15 +631,6 @@ export default function Dashboard() {
         </div>
       )}
 
-      <div>
-        <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
-          <LayoutDashboard className="text-primary-600 dark:text-primary-400" size={32} />
-          Tableau de bord
-        </h1>
-        <p className="text-sm sm:text-base text-gray-600 dark:text-gray-400">
-          Gérez vos points de livraison
-        </p>
-      </div>
 
       {/* Info Section */}
       {pdls.length === 0 && (

--- a/apps/web/src/pages/EcoWatt.tsx
+++ b/apps/web/src/pages/EcoWatt.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Zap, AlertTriangle, CheckCircle, AlertCircle, Calendar } from 'lucide-react'
+import { AlertTriangle, CheckCircle, AlertCircle, Calendar } from 'lucide-react'
 import { ecowattApi, type EcoWattSignal, type EcoWattStatistics } from '../api/ecowatt'
 
 
@@ -135,16 +135,6 @@ export default function EcoWatt() {
 
   return (
     <div className="pt-6 space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
-          <Zap className="text-primary-600 dark:text-primary-400" size={32} />
-          EcoWatt - Signal RTE
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400">
-          Suivez en temps réel l'état du réseau électrique français et anticipez les tensions
-        </p>
-      </div>
 
       {/* Current Signal */}
       <div className={`card p-6 border-l-4 ${currentInfo.borderColor}`}>

--- a/apps/web/src/pages/Tempo.tsx
+++ b/apps/web/src/pages/Tempo.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query'
-import { Calendar } from 'lucide-react'
 import { tempoApi, type TempoDay } from '../api/tempo'
 
 export default function Tempo() {
@@ -199,13 +198,6 @@ export default function Tempo() {
 
   return (
     <div className="pt-6 w-full">
-      <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
-        <Calendar className="text-primary-600 dark:text-primary-400" size={32} />
-        Calendrier Tempo
-      </h1>
-      <p className="text-gray-600 dark:text-gray-400 mb-6">
-        Historique des jours Tempo bleus, blancs et rouges fourni par RTE
-      </p>
 
       {/* Current Season Summary */}
       {currentSeasonStats && (


### PR DESCRIPTION
…nd Contribute pages

- Extend PageHeader to display PDL selector with fetch button on all main pages
- Remove redundant H1 titles from individual pages (now handled by PageHeader)
- Always fetch all data (consumption + production) regardless of current page
- Consistent UX across the application with unified header component

🤖 Generated with [Claude Code](https://claude.com/claude-code)