### PR TITLE
Use dev-{sha} tag for Docker images on main push

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., 1.0.0). Leave empty for "latest"'
+        description: 'Version tag (e.g., 1.0.0). Leave empty for "dev-{sha}"'
         required: false
         default: ''
 
@@ -31,12 +31,16 @@ jobs:
         id: version
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
+            # Manual input: use as-is
             VERSION="${{ github.event.inputs.version }}"
           elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Version tag: strip 'v' prefix
             VERSION="${{ github.ref_name }}"
             VERSION="${VERSION#v}"
           else
-            VERSION="latest"
+            # Branch push (main): use dev-{short_sha}
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            VERSION="dev-${SHORT_SHA}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"


### PR DESCRIPTION
## Summary

- Docker images built from main branch now use `dev-{short_sha}` format (e.g., `dev-9289f76`) for better traceability
- The `latest` tag is still applied alongside the dev tag
- Release tags (`v*`) behavior unchanged: use version number + `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)