### PR TITLE
Adapt consumption charts to pricing option type

### DIFF
--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -159,6 +159,8 @@ export default function PageHeader() {
               <div className="text-sm text-gray-600 dark:text-gray-400 italic">
                 {location.pathname === '/production'
                   ? 'Aucun PDL de production non lié trouvé'
+                  : location.pathname === '/consumption'
+                  ? 'Aucun PDL avec l\'option consommation activée'
                   : 'Aucun point de livraison actif trouvé'}
               </div>
             ) : (

--- a/apps/web/src/pages/Consumption/components/HcHpDistribution.tsx
+++ b/apps/web/src/pages/Consumption/components/HcHpDistribution.tsx
@@ -19,7 +19,14 @@ interface HcHpDistributionProps {
 export function HcHpDistribution({ hcHpByYear, selectedPDLDetails }: HcHpDistributionProps) {
   const [selectedHcHpPeriod, setSelectedHcHpPeriod] = useState(0)
 
-  if (hcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours) {
+  // Don't show HC/HP distribution if:
+  // - No data available
+  // - No offpeak hours configured
+  // - User has BASE pricing (no HC/HP distinction)
+  const pricingOption = selectedPDLDetails?.pricing_option
+  const isBasePricing = pricingOption === 'BASE'
+
+  if (hcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours || isBasePricing) {
     return null
   }
 

--- a/apps/web/src/pages/Consumption/components/MonthlyHcHp.tsx
+++ b/apps/web/src/pages/Consumption/components/MonthlyHcHp.tsx
@@ -43,7 +43,14 @@ export function MonthlyHcHp({ monthlyHcHpByYear, selectedPDLDetails, isDarkMode 
   const [refAreaRight, setRefAreaRight] = useState<string>('')
   const [zoomDomain, setZoomDomain] = useState<{ left: number; right: number } | null>(null)
 
-  if (monthlyHcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours) {
+  // Don't show Monthly HC/HP if:
+  // - No data available
+  // - No offpeak hours configured
+  // - User has BASE pricing (no HC/HP distinction)
+  const pricingOption = selectedPDLDetails?.pricing_option
+  const isBasePricing = pricingOption === 'BASE'
+
+  if (monthlyHcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours || isBasePricing) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- Hide HC/HP distribution and monthly charts for BASE pricing option
- Only display time-of-use tariff-specific charts for non-BASE pricing
- Improve error messaging on consumption page

🤖 Generated with [Claude Code](https://claude.com/claude-code)