### PR TITLE
Add consumption submenu with kWh and Euro tabs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,7 +25,8 @@ import AdminRoles from './pages/AdminRoles'
 import AdminLogs from './pages/AdminLogs'
 import Tempo from './pages/Tempo'
 import EcoWatt from './pages/EcoWatt'
-import Consumption from './pages/Consumption'
+import ConsumptionKwh from './pages/ConsumptionKwh'
+import ConsumptionEuro from './pages/ConsumptionEuro'
 import Production from './pages/Production'
 import FAQ from './pages/FAQ'
 import ApiDocs from './pages/ApiDocs'
@@ -191,12 +192,27 @@ function App() {
           </ProtectedRoute>
         }
       />
+      {/* Consumption routes with submenu */}
       <Route
         path="/consumption"
+        element={<Navigate to="/consumption_kwh" replace />}
+      />
+      <Route
+        path="/consumption_kwh"
         element={
           <ProtectedRoute>
             <Layout>
-              <Consumption />
+              <ConsumptionKwh />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/consumption_euro"
+        element={
+          <ProtectedRoute>
+            <Layout>
+              <ConsumptionEuro />
             </Layout>
           </ProtectedRoute>
         }

--- a/apps/web/src/components/ConsumptionTabs.tsx
+++ b/apps/web/src/components/ConsumptionTabs.tsx
@@ -1,0 +1,42 @@
+import { Link, useLocation } from 'react-router-dom'
+import { Zap, Euro } from 'lucide-react'
+
+interface Tab {
+  name: string
+  path: string
+  icon: typeof Zap
+}
+
+const tabs: Tab[] = [
+  { name: 'kWh', path: '/consumption_kwh', icon: Zap },
+  { name: 'Euro', path: '/consumption_euro', icon: Euro },
+]
+
+export default function ConsumptionTabs() {
+  const location = useLocation()
+
+  return (
+    <div className="w-full border-b border-gray-200 dark:border-gray-700 overflow-x-auto bg-white dark:bg-gray-800">
+      <nav className="flex justify-center gap-1 min-w-max px-3 sm:px-4 lg:px-6" aria-label="Tabs">
+        {tabs.map((tab) => {
+          const isActive = location.pathname === tab.path
+          const Icon = tab.icon
+          return (
+            <Link
+              key={tab.path}
+              to={tab.path}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                isActive
+                  ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
+              }`}
+            >
+              <Icon size={16} />
+              {tab.name}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import toast, { Toaster } from 'react-hot-toast'
 import AdminTabs from './AdminTabs'
 import ApiDocsTabs from './ApiDocsTabs'
+import ConsumptionTabs from './ConsumptionTabs'
 import PageHeader from './PageHeader'
 import { PageTransition } from './PageTransition'
 import { useQueryClient } from '@tanstack/react-query'
@@ -34,13 +35,16 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   // Menu items
   const menuItems = [
     { to: '/dashboard', icon: Home, label: 'Tableau de bord' },
-    { to: '/consumption', icon: TrendingUp, label: 'Consommation' },
+    { to: '/consumption_kwh', icon: TrendingUp, label: 'Consommation' },
     { to: '/production', icon: Sun, label: 'Production' },
     { to: '/simulator', icon: Calculator, label: 'Simulateur' },
     { to: '/contribute', icon: Users, label: 'Contribuer' },
     { to: '/tempo', icon: Calendar, label: 'Tempo' },
     { to: '/ecowatt', icon: Zap, label: 'EcoWatt' },
   ]
+
+  // Check if we're on a consumption page (for active state and tabs)
+  const isConsumptionPage = location.pathname.startsWith('/consumption')
 
   // Clear cache function (admin only)
   const handleClearCache = async () => {
@@ -154,26 +158,32 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         {/* Navigation */}
         <nav className="flex-1 overflow-y-auto py-4">
           <div className="space-y-1 px-2">
-            {menuItems.map((item) => (
-              <Link
-                key={item.to}
-                to={item.to}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-md transition-colors ${
-                  location.pathname === item.to
-                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
-                    : 'hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`}
-                title={sidebarCollapsed ? item.label : ''}
-                data-tour={item.to === '/consumption' ? 'nav-consumption' :
-                          item.to === '/simulator' ? 'nav-simulator' :
-                          item.to === '/contribute' ? 'nav-contribute' : undefined}
-              >
-                <item.icon size={20} className="flex-shrink-0" />
-                {!sidebarCollapsed && (
-                  <span className="font-medium">{item.label}</span>
-                )}
-              </Link>
-            ))}
+            {menuItems.map((item) => {
+              // Special handling for consumption - active if any consumption page
+              const isActive = item.to === '/consumption_kwh'
+                ? isConsumptionPage
+                : location.pathname === item.to
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className={`flex items-center gap-3 px-3 py-2.5 rounded-md transition-colors ${
+                    isActive
+                      ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                      : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                  }`}
+                  title={sidebarCollapsed ? item.label : ''}
+                  data-tour={item.to === '/consumption_kwh' ? 'nav-consumption' :
+                            item.to === '/simulator' ? 'nav-simulator' :
+                            item.to === '/contribute' ? 'nav-contribute' : undefined}
+                >
+                  <item.icon size={20} className="flex-shrink-0" />
+                  {!sidebarCollapsed && (
+                    <span className="font-medium">{item.label}</span>
+                  )}
+                </Link>
+              )
+            })}
 
             {/* Admin Link */}
             {canAccessAdmin() && (
@@ -326,21 +336,27 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         {/* Navigation */}
         <nav className="flex-1 overflow-y-auto py-4">
           <div className="space-y-1 px-2">
-            {menuItems.map((item) => (
-              <Link
-                key={item.to}
-                to={item.to}
-                onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-md transition-colors ${
-                  location.pathname === item.to
-                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
-                    : 'hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`}
-              >
-                <item.icon size={20} />
-                <span className="font-medium">{item.label}</span>
-              </Link>
-            ))}
+            {menuItems.map((item) => {
+              // Special handling for consumption - active if any consumption page
+              const isActive = item.to === '/consumption_kwh'
+                ? isConsumptionPage
+                : location.pathname === item.to
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={`flex items-center gap-3 px-3 py-2.5 rounded-md transition-colors ${
+                    isActive
+                      ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                      : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  <item.icon size={20} />
+                  <span className="font-medium">{item.label}</span>
+                </Link>
+              )
+            })}
 
             {canAccessAdmin() && (
               <>
@@ -459,11 +475,12 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           <PageHeader />
           {location.pathname.startsWith('/admin') && <AdminTabs />}
           {location.pathname.startsWith('/api-docs') && <ApiDocsTabs />}
+          {isConsumptionPage && <ConsumptionTabs />}
         </div>
 
         {/* Main Content */}
         <main className={`flex-1 bg-gray-50 dark:bg-gray-900 ${isAdminLogsPage ? 'overflow-hidden' : 'overflow-y-auto'}`}>
-          <div className={`container mx-auto px-3 sm:px-4 lg:px-6 max-w-[1920px] ${isAdminLogsPage ? 'h-full pb-0' : 'pb-6'} ${(location.pathname.startsWith('/admin') || location.pathname.startsWith('/api-docs')) ? 'pt-4' : ''}`}>
+          <div className={`container mx-auto px-3 sm:px-4 lg:px-6 max-w-[1920px] ${isAdminLogsPage ? 'h-full pb-0' : 'pb-6'} ${(location.pathname.startsWith('/admin') || location.pathname.startsWith('/api-docs') || isConsumptionPage) ? 'pt-4' : ''}`}>
             <PageTransition key={location.pathname}>
               {children}
             </PageTransition>

--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
-import { TrendingUp, Sun, Calculator, Download, Lock, LayoutDashboard, Calendar, Zap, Users, AlertCircle, BookOpen, Settings as SettingsIcon, Key, Shield, FileText, Activity } from 'lucide-react'
+import { TrendingUp, Sun, Calculator, Download, Lock, LayoutDashboard, Calendar, Zap, Users, AlertCircle, BookOpen, Settings as SettingsIcon, Key, Shield, FileText, Activity, Euro } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { pdlApi } from '@/api/pdl'
 import { usePdlStore } from '@/stores/pdlStore'
@@ -12,7 +12,7 @@ import type { PDL } from '@/types/api'
 
 // Pages qui affichent le sélecteur de PDL avec bouton "Récupérer"
 const PDL_SELECTOR_PAGES = [
-  '/consumption', '/production', '/simulator', '/dashboard', '/tempo', '/ecowatt', '/contribute',
+  '/consumption_kwh', '/consumption_euro', '/production', '/simulator', '/dashboard', '/tempo', '/ecowatt', '/contribute',
   '/faq', '/api-docs', '/api-docs/auth', '/settings',
   '/admin', '/admin/users', '/admin/tempo', '/admin/ecowatt', '/admin/contributions', '/admin/offers', '/admin/roles', '/admin/logs', '/admin/add-pdl'
 ]
@@ -20,7 +20,8 @@ const PDL_SELECTOR_PAGES = [
 // Configuration des titres et icônes par page
 const PAGE_CONFIG: Record<string, { title: string; icon: typeof TrendingUp; subtitle?: string }> = {
   '/dashboard': { title: 'Tableau de bord', icon: LayoutDashboard, subtitle: 'Gérez vos points de livraison' },
-  '/consumption': { title: 'Consommation', icon: TrendingUp, subtitle: 'Visualisez et analysez votre consommation électrique' },
+  '/consumption_kwh': { title: 'Consommation', icon: TrendingUp, subtitle: 'Visualisez et analysez votre consommation électrique en kWh' },
+  '/consumption_euro': { title: 'Consommation', icon: Euro, subtitle: 'Visualisez et analysez le coût de votre consommation en euros' },
   '/production': { title: 'Production', icon: Sun, subtitle: 'Visualisez et analysez votre production d\'énergie solaire' },
   '/simulator': { title: 'Comparateur des abonnements', icon: Calculator, subtitle: 'Comparez automatiquement le coût de toutes les offres disponibles' },
   '/tempo': { title: 'Calendrier Tempo', icon: Calendar, subtitle: 'Historique des jours Tempo bleus, blancs et rouges fourni par RTE' },
@@ -107,6 +108,9 @@ export default function PageHeader() {
   const Icon = config.icon
   const activePdls = pdls.filter((p: PDL) => p.is_active)
 
+  // Check if on a consumption page
+  const isConsumptionPage = location.pathname.startsWith('/consumption')
+
   // Filter PDLs based on page
   const displayedPdls = location.pathname === '/production'
     ? (() => {
@@ -130,7 +134,7 @@ export default function PageHeader() {
 
         return [...consumptionWithProduction, ...standaloneProduction]
       })()
-    : location.pathname === '/consumption'
+    : isConsumptionPage
     ? activePdls.filter((pdl: PDL) => pdl.has_consumption)
     : activePdls
 
@@ -159,7 +163,7 @@ export default function PageHeader() {
               <div className="text-sm text-gray-600 dark:text-gray-400 italic">
                 {location.pathname === '/production'
                   ? 'Aucun PDL de production non lié trouvé'
-                  : location.pathname === '/consumption'
+                  : isConsumptionPage
                   ? 'Aucun PDL avec l\'option consommation activée'
                   : 'Aucun point de livraison actif trouvé'}
               </div>

--- a/apps/web/src/pages/ConsumptionEuro/index.tsx
+++ b/apps/web/src/pages/ConsumptionEuro/index.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react'
+import { Euro, Database, ArrowRight, AlertCircle } from 'lucide-react'
+import { usePdlStore } from '@/stores/pdlStore'
+
+export default function ConsumptionEuro() {
+  const { selectedPdl: selectedPDL } = usePdlStore()
+  const [isDarkMode, setIsDarkMode] = useState(false)
+
+  // Detect dark mode
+  useEffect(() => {
+    const checkDarkMode = () => {
+      setIsDarkMode(document.documentElement.classList.contains('dark'))
+    }
+    checkDarkMode()
+    const observer = new MutationObserver(checkDarkMode)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div className="w-full">
+      {/* Coming Soon / Work in Progress State */}
+      <div className="rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+        <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+          <div className="w-20 h-20 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center mb-6">
+            <Euro className="w-10 h-10 text-amber-600 dark:text-amber-400" />
+          </div>
+          <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            Consommation en Euros
+          </h3>
+          <p className="text-gray-600 dark:text-gray-400 max-w-md mb-6">
+            Cette fonctionnalité est en cours de développement. Elle vous permettra de visualiser
+            votre consommation électrique convertie en euros selon les tarifs de votre fournisseur.
+          </p>
+
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 max-w-lg">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+              <div className="text-left">
+                <p className="text-sm text-blue-800 dark:text-blue-200 font-medium mb-1">
+                  Fonctionnalités à venir :
+                </p>
+                <ul className="text-sm text-blue-700 dark:text-blue-300 list-disc list-inside space-y-1">
+                  <li>Conversion de la consommation kWh en euros</li>
+                  <li>Application des tarifs HC/HP selon votre abonnement</li>
+                  <li>Comparaison des coûts par période</li>
+                  <li>Estimation de la facture mensuelle</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <span>Récupérez vos données kWh</span>
+            <ArrowRight className="w-4 h-4" />
+            <span>Sélectionnez une offre tarifaire</span>
+            <ArrowRight className="w-4 h-4" />
+            <span>Visualisez vos coûts</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/AnnualCurve.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/AnnualCurve.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceArea } from 'recharts'
+import { Download, ZoomOut } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { ModernButton } from './ModernButton'
+
+interface MonthData {
+  month: string
+  monthLabel: string
+  consumption: number
+  consommation: number
+}
+
+interface YearData {
+  label: string
+  byMonth: MonthData[]
+}
+
+interface AnnualCurveProps {
+  chartData: {
+    byMonth: MonthData[]
+    yearsByPeriod?: YearData[]
+  }
+  isDarkMode: boolean
+}
+
+export function AnnualCurve({ chartData, isDarkMode }: AnnualCurveProps) {
+  // If we have yearsByPeriod array from chartData, use it, otherwise create a single year
+  const yearsData: YearData[] = chartData.yearsByPeriod || [{
+    label: 'Année courante',
+    byMonth: chartData.byMonth
+  }]
+
+  // Track selected years with a Set (allows multiple selections)
+  // Default to the most recent year (last index after reverse)
+  const [selectedYears, setSelectedYears] = useState<Set<number>>(
+    new Set([yearsData.length > 0 ? yearsData.length - 1 : 0])
+  )
+
+  // Zoom state
+  const [refAreaLeft, setRefAreaLeft] = useState<string>('')
+  const [refAreaRight, setRefAreaRight] = useState<string>('')
+  const [zoomDomain, setZoomDomain] = useState<{ left: number; right: number } | null>(null)
+
+  if (yearsData.length === 0) {
+    return null
+  }
+
+  const toggleYearSelection = (index: number) => {
+    const newSelection = new Set(selectedYears)
+    if (newSelection.has(index)) {
+      // Don't allow deselecting the last selected year
+      if (newSelection.size > 1) {
+        newSelection.delete(index)
+      }
+    } else {
+      newSelection.add(index)
+    }
+    setSelectedYears(newSelection)
+  }
+
+  const handleExport = () => {
+    const selectedData = Array.from(selectedYears)
+      .map(index => yearsData[index])
+      .filter((yearData): yearData is YearData => yearData !== undefined && yearData.byMonth !== undefined)
+      .sort((a, b) => b.label.localeCompare(a.label))
+    const jsonData = JSON.stringify(selectedData, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    const yearLabels = selectedData.map(d => d.label).join(', ')
+    toast.success(`Données de ${yearLabels} copiées dans le presse-papier`)
+  }
+
+  const zoomOut = () => {
+    setZoomDomain(null)
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  const zoom = () => {
+    if (!refAreaLeft || !refAreaRight) return
+
+    // Get indices
+    let left = chartDataMerged.findIndex(item => item.monthLabel === refAreaLeft)
+    let right = chartDataMerged.findIndex(item => item.monthLabel === refAreaRight)
+
+    if (left === right || left === -1 || right === -1) {
+      setRefAreaLeft('')
+      setRefAreaRight('')
+      return
+    }
+
+    // Swap if needed
+    if (left > right) [left, right] = [right, left]
+
+    setZoomDomain({ left, right })
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  // Prepare chart data with all selected years
+  const chartDataMerged = (() => {
+    const selectedYearsData = Array.from(selectedYears)
+      .map(index => yearsData[index])
+      .filter((yearData): yearData is YearData => yearData !== undefined && yearData.byMonth !== undefined)
+      .sort((a, b) => b.label.localeCompare(a.label)) // Sort by year descending
+
+    // Create a map using normalized month keys (YYYY-MM) to overlay years
+    const monthsMap = new Map<string, any>()
+
+    selectedYearsData.forEach((yearData) => {
+      yearData.byMonth.forEach(monthData => {
+        // Extract month from YYYY-MM format (e.g., "2025-01" -> "01")
+        const monthOnly = monthData.month.substring(5, 7) // Get MM part
+
+        // Create a normalized month label (e.g., "janv.")
+        const normalizedDate = new Date(`2000-${monthOnly}-01`)
+        const normalizedLabel = normalizedDate.toLocaleDateString('fr-FR', { month: 'short' })
+
+        if (!monthsMap.has(monthOnly)) {
+          monthsMap.set(monthOnly, {
+            monthLabel: normalizedLabel,
+            monthNum: monthOnly
+          })
+        }
+
+        const entry = monthsMap.get(monthOnly)!
+        // Add data for this year
+        entry[`consumption_${yearData.label}`] = monthData.consumption
+      })
+    })
+
+    // Convert to array and sort by month number
+    return Array.from(monthsMap.values()).sort((a, b) =>
+      a.monthNum.localeCompare(b.monthNum)
+    )
+  })()
+
+  const selectedYearsData = Array.from(selectedYears)
+    .map(index => yearsData[index])
+    .filter((yearData): yearData is YearData => yearData !== undefined && yearData.byMonth !== undefined)
+    .sort((a, b) => b.label.localeCompare(a.label))
+
+  const colors = ['#3B82F6', '#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#06B6D4']
+
+  // Get display data based on zoom
+  const displayData = zoomDomain
+    ? chartDataMerged.slice(zoomDomain.left, zoomDomain.right + 1)
+    : chartDataMerged
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+        Courbe de consommation annuelle
+      </h3>
+
+      {/* Tabs and buttons - responsive layout */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        {/* Tabs on the left - Allow multiple selection */}
+        <div className="flex gap-2 flex-1 overflow-x-auto overflow-y-hidden py-3 px-2 no-scrollbar">
+          {[...yearsData].reverse().map((yearData, idx) => {
+            const originalIndex = yearsData.length - 1 - idx
+            const isSelected = selectedYears.has(originalIndex)
+            return (
+              <ModernButton
+                key={yearData.label}
+                variant="tab"
+                size="md"
+                isActive={isSelected}
+                onClick={() => toggleYearSelection(originalIndex)}
+                className="flex-1 min-w-[100px]"
+              >
+                {yearData.label}
+              </ModernButton>
+            )
+          })}
+        </div>
+
+        {/* Action buttons on the right */}
+        <div className="flex gap-2">
+          {zoomDomain && (
+            <ModernButton
+              variant="gradient"
+              size="sm"
+              icon={ZoomOut}
+              iconPosition="left"
+              onClick={zoomOut}
+              title="Réinitialiser le zoom"
+              className="bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700"
+            >
+              Réinitialiser
+            </ModernButton>
+          )}
+          <ModernButton
+            variant="gradient"
+            size="sm"
+            icon={Download}
+            iconPosition="left"
+            onClick={handleExport}
+          >
+            Export JSON
+          </ModernButton>
+        </div>
+      </div>
+
+      {/* Display selected years chart */}
+      <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
+        <ResponsiveContainer width="100%" height={350}>
+          <LineChart
+            data={displayData}
+            onMouseDown={(e) => e && e.activeLabel && setRefAreaLeft(e.activeLabel)}
+            onMouseMove={(e) => refAreaLeft && e && e.activeLabel && setRefAreaRight(e.activeLabel)}
+            onMouseUp={zoom}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#9CA3AF" opacity={0.3} />
+            <XAxis
+              dataKey="monthLabel"
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '12px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+            />
+            <YAxis
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '14px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+              tickFormatter={(value) => `${(value / 1000).toFixed(0)} kWh`}
+              label={{
+                value: 'Consommation (kWh)',
+                angle: -90,
+                position: 'insideLeft',
+                fill: isDarkMode ? '#FFFFFF' : '#6B7280'
+              }}
+            />
+            <Tooltip
+              cursor={{ stroke: colors[0], strokeWidth: 2 }}
+              contentStyle={{
+                backgroundColor: '#1F2937',
+                border: '1px solid #374151',
+                borderRadius: '8px',
+                color: '#F9FAFB'
+              }}
+              formatter={(value: number) => [
+                `${(value / 1000).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh`,
+                'Consommation'
+              ]}
+            />
+            <Legend />
+
+            {/* Dynamically create lines for each selected year */}
+            {selectedYearsData.map((yearData, index) => (
+              <Line
+                key={yearData.label}
+                type="monotone"
+                dataKey={`consumption_${yearData.label}`}
+                stroke={colors[index % colors.length]}
+                strokeWidth={2}
+                dot={{ fill: colors[index % colors.length], r: 4 }}
+                activeDot={{ r: 6 }}
+                name={yearData.label}
+              />
+            ))}
+
+            {/* Selection area for zooming */}
+            {refAreaLeft && refAreaRight && (
+              <ReferenceArea
+                x1={refAreaLeft}
+                x2={refAreaRight}
+                strokeOpacity={0.3}
+                fill={isDarkMode ? "#6366f1" : "#818cf8"}
+                fillOpacity={0.3}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+
+        {/* Zoom instruction */}
+        {!zoomDomain && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
+            💡 Cliquez et glissez sur le graphique pour zoomer sur une période
+          </p>
+        )}
+      </div>
+
+      <div className="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+        <p className="text-sm text-blue-800 dark:text-blue-200">
+          <strong>ℹ️ Note :</strong> Cette courbe présente votre consommation mensuelle sur des périodes glissantes de 365 jours. Vous pouvez sélectionner plusieurs périodes pour les comparer.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/ConfirmModal.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/ConfirmModal.tsx
@@ -1,0 +1,58 @@
+import { AlertCircle, Trash2 } from 'lucide-react'
+import type { ConfirmModalProps } from '../types/consumption.types'
+
+export function ConfirmModal({ showConfirmModal, setShowConfirmModal, confirmClearCache }: ConfirmModalProps) {
+  if (!showConfirmModal) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full p-6 border border-gray-200 dark:border-gray-700">
+        {/* Modal Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex-shrink-0 w-12 h-12 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+            <AlertCircle className="text-red-600 dark:text-red-400" size={24} />
+          </div>
+          <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
+            Confirmation requise
+          </h3>
+        </div>
+
+        {/* Modal Content */}
+        <div className="mb-6">
+          <p className="text-gray-700 dark:text-gray-300 mb-4">
+            Êtes-vous sûr de vouloir vider tout le cache ?
+          </p>
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-500 p-4 rounded">
+            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+              <strong>⚠️ Attention :</strong> Cette action va supprimer :
+            </p>
+            <ul className="text-sm text-yellow-700 dark:text-yellow-300 mt-2 ml-4 list-disc space-y-1">
+              <li>Tout le cache du navigateur (localStorage, sessionStorage, IndexedDB)</li>
+              <li>Toutes les données en cache Redis</li>
+            </ul>
+            <p className="text-sm text-yellow-800 dark:text-yellow-200 mt-3">
+              Cette action est <strong>irréversible</strong> et la page se rechargera automatiquement.
+            </p>
+          </div>
+        </div>
+
+        {/* Modal Actions */}
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={() => setShowConfirmModal(false)}
+            className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors font-medium"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={confirmClearCache}
+            className="px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors font-medium flex items-center gap-2"
+          >
+            <Trash2 size={18} />
+            Vider le cache
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/DataFetchSection.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/DataFetchSection.tsx
@@ -1,0 +1,93 @@
+import { Download, Settings, Lock } from 'lucide-react'
+import type { PDL } from '@/types/api'
+import { useIsDemo } from '@/hooks/useIsDemo'
+import { ModernButton } from './ModernButton'
+
+interface DataFetchSectionProps {
+  activePdls: PDL[]
+  selectedPDL: string
+  onFetchData: () => void
+  isLoading: boolean
+  isLoadingDetailed: boolean
+  dataLimitWarning: string | null
+  children?: React.ReactNode
+}
+
+export function DataFetchSection({
+  activePdls,
+  selectedPDL,
+  onFetchData,
+  isLoading,
+  isLoadingDetailed,
+  dataLimitWarning,
+  children
+}: DataFetchSectionProps) {
+  const isDemo = useIsDemo()
+
+  return (
+    <div className="card">
+      {/* Configuration Header */}
+      <div className="flex items-center gap-2 mb-6">
+        <Settings className="text-primary-600 dark:text-primary-400" size={20} />
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Configuration</h2>
+      </div>
+
+      <div className="space-y-6">
+        {/* No active PDL message */}
+        {activePdls.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            Aucun PDL actif disponible. Veuillez en ajouter un depuis votre{' '}
+            <a href="/dashboard" className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 underline">
+              tableau de bord
+            </a>.
+          </div>
+        )}
+
+        {/* Warning if PDL has limited data */}
+        {dataLimitWarning && (
+          <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center gap-2">
+            <span className="text-blue-600 dark:text-blue-400 text-lg flex-shrink-0">ℹ️</span>
+            <p className="text-sm text-blue-800 dark:text-blue-200">
+              {dataLimitWarning}
+            </p>
+          </div>
+        )}
+
+        {/* Fetch Button - Always show if there are active PDLs */}
+        {activePdls.length > 0 && (
+          <>
+            <ModernButton
+              variant="primary"
+              size="lg"
+              fullWidth
+              onClick={onFetchData}
+              disabled={!selectedPDL || isLoading || isLoadingDetailed || isDemo}
+              icon={isDemo ? Lock : Download}
+              iconPosition="left"
+              loading={isLoading || isLoadingDetailed}
+            >
+              {isLoading || isLoadingDetailed
+                ? 'Récupération en cours...'
+                : isDemo
+                  ? 'Récupération bloquée en mode démo'
+                  : 'Récupérer l\'historique'
+              }
+            </ModernButton>
+
+            {isDemo && (
+              <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                <p className="text-sm text-amber-800 dark:text-amber-200">
+                  <strong>Mode Démo :</strong> Le compte démo dispose déjà de 3 ans de données fictives.
+                  La récupération depuis l'API Enedis est désactivée.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Children (LoadingProgress) */}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/HcHpDistribution.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/HcHpDistribution.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react'
+import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { Download, Info } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { ModernButton } from './ModernButton'
+
+interface HcHpData {
+  year: string
+  hcKwh: number
+  hpKwh: number
+  totalKwh: number
+}
+
+interface HcHpDistributionProps {
+  hcHpByYear: HcHpData[]
+  selectedPDLDetails: any
+}
+
+export function HcHpDistribution({ hcHpByYear, selectedPDLDetails }: HcHpDistributionProps) {
+  const [selectedHcHpPeriod, setSelectedHcHpPeriod] = useState(0)
+
+  // Don't show HC/HP distribution if:
+  // - No data available
+  // - No offpeak hours configured
+  // - User has BASE pricing (no HC/HP distinction)
+  const pricingOption = selectedPDLDetails?.pricing_option
+  const isBasePricing = pricingOption === 'BASE'
+
+  if (hcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours || isBasePricing) {
+    return null
+  }
+
+  const handleExportAll = () => {
+    const jsonData = JSON.stringify(hcHpByYear, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    toast.success('Données HC/HP copiées dans le presse-papier')
+  }
+
+  const handleExportPeriod = (yearData: HcHpData) => {
+    const jsonData = JSON.stringify(yearData, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    toast.success('Données HC/HP copiées')
+  }
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+        Répartition HC/HP par année
+      </h3>
+
+      {/* Tabs and export button - responsive layout */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        {/* Tabs on the left */}
+        <div className="flex gap-2 flex-1 overflow-x-auto overflow-y-hidden py-3 px-2 no-scrollbar">
+          {hcHpByYear.map((yearData, index) => {
+            // Extract the year from the end date
+            const endYear = yearData.year.split(' - ')[1]?.split(' ').pop() || yearData.year
+
+            return (
+              <ModernButton
+                key={yearData.year}
+                variant="tab"
+                size="md"
+                isActive={selectedHcHpPeriod === index}
+                onClick={() => setSelectedHcHpPeriod(index)}
+                className="flex-1 min-w-[80px]"
+              >
+                {endYear}
+              </ModernButton>
+            )
+          })}
+        </div>
+
+        {/* Export button on the right */}
+        <ModernButton
+          variant="gradient"
+          size="sm"
+          icon={Download}
+          iconPosition="left"
+          onClick={handleExportAll}
+        >
+          Export JSON
+        </ModernButton>
+      </div>
+
+      {/* Selected Period Chart */}
+      {hcHpByYear[selectedHcHpPeriod] && (() => {
+        const yearData = hcHpByYear[selectedHcHpPeriod]
+        const hcPercentage = yearData.totalKwh > 0 ? (yearData.hcKwh / yearData.totalKwh) * 100 : 0
+        const hpPercentage = yearData.totalKwh > 0 ? (yearData.hpKwh / yearData.totalKwh) * 100 : 0
+
+        const pieData = [
+          { name: 'Heures Creuses (HC)', value: yearData.hcKwh, color: '#3b82f6' },
+          { name: 'Heures Pleines (HP)', value: yearData.hpKwh, color: '#f97316' },
+        ]
+
+        return (
+          <div className="bg-gray-50 dark:bg-gray-700/30 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
+            <div className="flex items-center justify-between mb-4">
+              <h4 className="text-base font-semibold text-gray-900 dark:text-white">
+                {yearData.year}
+              </h4>
+              <ModernButton
+                variant="gradient"
+                size="sm"
+                icon={Download}
+                onClick={() => handleExportPeriod(yearData)}
+                className="!px-2 !py-1.5"
+              >
+                <span className="sr-only">Export période</span>
+              </ModernButton>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* Pie Chart - Fixed size to avoid ResponsiveContainer rendering delay */}
+              <div className="flex items-center justify-center">
+                <PieChart width={280} height={280}>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    labelLine={false}
+                    label={({ name, percent }: { name?: string; percent?: number }) =>
+                      `${name?.split(' ')[0] || ''} ${((percent || 0) * 100).toFixed(1)}%`
+                    }
+                    outerRadius={100}
+                    fill="#8884d8"
+                    dataKey="value"
+                    isAnimationActive={false}
+                  >
+                    {pieData.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={entry.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'rgba(255, 255, 255, 0.95)',
+                      border: '1px solid #ccc',
+                      borderRadius: '8px',
+                    }}
+                    formatter={(value: number) => `${value.toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh`}
+                  />
+                </PieChart>
+              </div>
+
+              {/* Statistics */}
+              <div className="flex flex-col justify-center gap-4">
+                {/* Heures Creuses */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Heures Creuses (HC)</p>
+                    <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
+                      {hcPercentage.toFixed(1)}%
+                    </span>
+                  </div>
+                  <p className="text-xl font-bold text-blue-600 dark:text-blue-400">
+                    {yearData.hcKwh.toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh
+                  </p>
+                </div>
+
+                {/* Heures Pleines */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Heures Pleines (HP)</p>
+                    <span className="text-sm font-medium text-orange-600 dark:text-orange-400">
+                      {hpPercentage.toFixed(1)}%
+                    </span>
+                  </div>
+                  <p className="text-xl font-bold text-orange-600 dark:text-orange-400">
+                    {yearData.hpKwh.toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh
+                  </p>
+                </div>
+
+                {/* Visual bar */}
+                <div className="mt-2">
+                  <div className="w-full h-4 bg-gray-200 dark:bg-gray-600 rounded-full overflow-hidden flex">
+                    <div
+                      className="bg-blue-500 dark:bg-blue-400 h-full transition-all"
+                      style={{ width: `${hcPercentage}%` }}
+                      title={`HC: ${hcPercentage.toFixed(1)}%`}
+                    />
+                    <div
+                      className="bg-orange-500 dark:bg-orange-400 h-full transition-all"
+                      style={{ width: `${hpPercentage}%` }}
+                      title={`HP: ${hpPercentage.toFixed(1)}%`}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Info message */}
+            <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+              <div className="flex items-start gap-2">
+                <Info className="text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" size={16} />
+                <p className="text-xs text-blue-800 dark:text-blue-300">
+                  Le total HC/HP peut différer légèrement de la "Consommation par années".
+                  Cette différence est due à une simulation basée sur les plages horaires HC/HP,
+                  car Enedis ne fournit pas ces données détaillées.
+                  De plus, Enedis transmet les données par paliers de 30 minutes : si le changement d'heure creuse/pleine
+                  intervient au milieu d'un intervalle de 30 minutes, la répartition HC/HP sera approximative à 30 minutes près.
+                  C'est la <strong>Consommation par années</strong> qui est la plus précise et qui sera facturée par votre fournisseur.
+                </p>
+              </div>
+            </div>
+          </div>
+        )
+      })()}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/InfoBlock.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/InfoBlock.tsx
@@ -1,0 +1,70 @@
+import { Info } from 'lucide-react'
+
+interface InfoBlockProps {
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+export function InfoBlock({ isExpanded, onToggle }: InfoBlockProps) {
+  return (
+    <div className="mt-6 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+      {/* Collapsible Header */}
+      <div
+        className="flex items-center justify-between p-6 cursor-pointer"
+        onClick={onToggle}
+      >
+        <div className="flex items-center gap-2">
+          <Info className="text-primary-600 dark:text-primary-400" size={20} />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Informations importantes
+          </h3>
+        </div>
+        <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+          {isExpanded ? (
+            <span className="text-sm">Réduire</span>
+          ) : (
+            <span className="text-sm">Développer</span>
+          )}
+          <svg
+            className={`w-5 h-5 transition-transform duration-200 ${
+              isExpanded ? 'rotate-180' : ''
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </div>
+
+      {/* Collapsible Content */}
+      {isExpanded && (
+        <div className="px-6 pb-6 space-y-4">
+          {/* Cache Information */}
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+              <strong>💾 Cache automatique :</strong> L'utilisation de la page de consommation active automatiquement le cache. Vos données de consommation seront stockées temporairement pour améliorer les performances et éviter de solliciter excessivement l'API Enedis. Les données en cache expirent automatiquement après <strong>24 heures</strong>.
+            </p>
+          </div>
+
+          {/* Data Source Information */}
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+            <div className="text-sm text-blue-800 dark:text-blue-200 space-y-2">
+              <p>
+                <strong>📊 Source des données :</strong>
+              </p>
+              <ul className="list-disc list-inside space-y-1 ml-2">
+                <li>Les données sont récupérées depuis l'API <strong>Enedis Data Connect</strong></li>
+                <li>Données quotidiennes : <strong>1095 jours</strong> d'historique (3 ans)</li>
+                <li>Données détaillées (30 min) : <strong>730 jours</strong> d'historique (2 ans)</li>
+                <li>Les données Enedis ne sont disponibles qu'en <strong>J-1</strong> (hier)</li>
+                <li>Les calculs HC/HP utilisent des <strong>périodes glissantes de 365 jours</strong>, non des années calendaires</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/LoadingProgress.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/LoadingProgress.tsx
@@ -1,0 +1,325 @@
+import { useState, useEffect } from 'react'
+import { Activity, ChevronDown, ChevronUp } from 'lucide-react'
+import type { LoadingProgressProps } from '../types/consumption.types'
+
+interface ExtendedLoadingProgressProps extends LoadingProgressProps {
+  dateRange: any
+  allLoadingComplete: boolean
+  isLoadingConsumption: boolean
+  isLoadingPower: boolean
+  consumptionResponse: any
+  maxPowerResponse: any
+  hasDataInCache: boolean
+}
+
+export function LoadingProgress({
+  isLoadingDetailed,
+  dailyLoadingComplete,
+  powerLoadingComplete,
+  loadingProgress,
+  hcHpCalculationComplete,
+  allLoadingComplete,
+  dateRange,
+  isLoadingConsumption,
+  isLoadingPower,
+  consumptionResponse,
+  maxPowerResponse,
+  hasDataInCache
+}: ExtendedLoadingProgressProps) {
+  const [isProgressExpanded, setIsProgressExpanded] = useState(false)
+  const [wasManuallyExpanded, setWasManuallyExpanded] = useState(false)
+
+  // Auto-collapse when loading completes (but only if NOT manually expanded)
+  useEffect(() => {
+    if (allLoadingComplete && isProgressExpanded && !wasManuallyExpanded) {
+      // Auto-collapse 2 seconds after completion (only if auto-expanded during loading)
+      const timer = setTimeout(() => {
+        setIsProgressExpanded(false)
+      }, 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [allLoadingComplete, isProgressExpanded, wasManuallyExpanded])
+
+  // Show if we have a dateRange OR if anything is loading/complete OR if cache exists
+  const hasAnyActivity = dateRange || isLoadingConsumption || isLoadingPower || isLoadingDetailed || allLoadingComplete || hasDataInCache
+
+  if (!hasAnyActivity) {
+    return null
+  }
+
+  // Calculate completion status for compact view
+  const tasks = [
+    { name: 'Quotidien', complete: dailyLoadingComplete, loading: isLoadingConsumption, error: consumptionResponse?.success === false },
+    { name: 'Puissance', complete: powerLoadingComplete, loading: isLoadingPower, error: maxPowerResponse?.success === false },
+    { name: 'Détaillé', complete: loadingProgress.total === 0 || (loadingProgress.total > 0 && loadingProgress.current === loadingProgress.total), loading: isLoadingDetailed && loadingProgress.total > 0, progress: loadingProgress.total > 0 ? `${loadingProgress.current}/${loadingProgress.total}` : null },
+    { name: 'HC/HP', complete: hcHpCalculationComplete || loadingProgress.total === 0, loading: !hcHpCalculationComplete && isLoadingDetailed && loadingProgress.total > 0 }
+  ]
+
+  return (
+    <div className="mt-6">
+      <div
+        onClick={() => {
+          const willExpand = !isProgressExpanded
+          setIsProgressExpanded(willExpand)
+          if (willExpand) {
+            setWasManuallyExpanded(true)
+          }
+        }}
+        className="flex items-center justify-between cursor-pointer hover:opacity-70 transition-opacity"
+      >
+        <div className="flex items-center gap-2">
+          <Activity className="text-primary-600 dark:text-primary-400" size={20} />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Progression du chargement
+          </h3>
+        </div>
+
+        {/* Compact status when collapsed */}
+        {!isProgressExpanded && (
+          <div className="flex items-center gap-3 text-xs">
+            {tasks.map((task, idx) => (
+              <div key={idx} className="flex items-center gap-1">
+                {task.complete ? (
+                  <svg className="h-4 w-4 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : task.error ? (
+                  <svg className="h-4 w-4 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                ) : task.loading ? (
+                  <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-primary-600"></div>
+                ) : (
+                  <div className="h-4 w-4 rounded-full border-2 border-gray-300 dark:border-gray-600"></div>
+                )}
+                <span className={`font-medium ${
+                  task.complete ? 'text-green-600 dark:text-green-400' :
+                  task.error ? 'text-red-600 dark:text-red-400' :
+                  task.loading ? 'text-primary-600 dark:text-primary-400' :
+                  'text-gray-500 dark:text-gray-400'
+                }`}>
+                  {task.name}
+                  {task.progress && ` (${task.progress})`}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+          {isProgressExpanded ? (
+            <span className="text-sm">Réduire</span>
+          ) : (
+            <span className="text-sm">Développer</span>
+          )}
+          {isProgressExpanded ? (
+            <ChevronUp size={20} className="text-gray-500" />
+          ) : (
+            <ChevronDown size={20} className="text-gray-500" />
+          )}
+        </div>
+      </div>
+
+      {isProgressExpanded && (
+        <div className="animate-in fade-in slide-in-from-top-2 duration-300 mt-4">
+          <div className="bg-gray-50 dark:bg-gray-900/30 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex flex-col gap-6">
+              {/* Daily consumption data loading */}
+              <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Chargement des données quotidiennes (3 ans)
+              </h3>
+              <div className="flex items-center gap-2">
+                {dailyLoadingComplete && !isLoadingConsumption ? (
+                  consumptionResponse?.success ? (
+                    <>
+                      <svg className="h-5 w-5 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                        Terminé
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <svg className="h-5 w-5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                      <span className="text-sm font-medium text-red-600 dark:text-red-400">
+                        Erreur
+                      </span>
+                    </>
+                  )
+                ) : (
+                  <>
+                    <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-green-600"></div>
+                    <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                      En cours...
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {consumptionResponse?.success === false && consumptionResponse?.error?.message ? (
+                <span className="text-red-600 dark:text-red-400">{consumptionResponse.error.message}</span>
+              ) : (
+                'Récupération des données de consommation depuis le cache ou l\'API Enedis'
+              )}
+            </p>
+          </div>
+
+        {/* Power data loading */}
+        <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Chargement de la puissance maximum (3 ans)
+              </h3>
+              <div className="flex items-center gap-2">
+                {powerLoadingComplete && !isLoadingPower ? (
+                  maxPowerResponse?.success ? (
+                    <>
+                      <svg className="h-5 w-5 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                        Terminé
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <svg className="h-5 w-5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                      <span className="text-sm font-medium text-red-600 dark:text-red-400">
+                        Erreur
+                      </span>
+                    </>
+                  )
+                ) : (
+                  <>
+                    <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-green-600"></div>
+                    <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                      En cours...
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {maxPowerResponse?.success === false && maxPowerResponse?.error?.message ? (
+                <span className="text-red-600 dark:text-red-400">{maxPowerResponse.error.message}</span>
+              ) : (
+                'Récupération des données de puissance maximum depuis le cache ou l\'API Enedis'
+              )}
+            </p>
+          </div>
+
+
+        {/* Detailed data loading progress */}
+        <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Chargement des données détaillées (2 ans)
+              </h3>
+              <div className="flex items-center gap-2">
+                {loadingProgress.total === 0 ? (
+                  <>
+                    <svg className="h-5 w-5 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                      Terminé
+                    </span>
+                  </>
+                ) : loadingProgress.current === loadingProgress.total ? (
+                  <>
+                    <svg className="h-5 w-5 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                      Terminé ({loadingProgress.total} semaines)
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-sm font-medium text-primary-600 dark:text-primary-400">
+                    {loadingProgress.current} / {loadingProgress.total} semaines
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Progress bar - only show if loading */}
+            {loadingProgress.total > 0 && loadingProgress.current < loadingProgress.total && (
+              <>
+                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-8 overflow-hidden">
+                  <div
+                    className="h-full bg-gradient-to-r from-primary-500 to-blue-500 transition-all duration-300 ease-out flex items-center justify-end pr-3"
+                    style={{ width: `${(loadingProgress.current / loadingProgress.total) * 100}%` }}
+                  >
+                    {loadingProgress.current > 0 && (
+                      <span className="text-sm font-bold text-white drop-shadow">
+                        {Math.round((loadingProgress.current / loadingProgress.total) * 100)}%
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Current range */}
+                {loadingProgress.currentRange && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
+                    <span className="font-mono bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
+                      {loadingProgress.currentRange}
+                    </span>
+                  </p>
+                )}
+              </>
+            )}
+
+            {/* Completion message */}
+            {loadingProgress.total === 0 && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Pas de données détaillées à charger
+              </p>
+            )}
+          </div>
+
+
+        {/* HC/HP calculation progress */}
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              Calcul des heures creuses / pleines
+            </h3>
+            <div className="flex items-center gap-2">
+              {hcHpCalculationComplete ? (
+                <>
+                  <svg className="h-5 w-5 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                    Terminé
+                  </span>
+                </>
+              ) : (
+                <>
+                  <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-green-600"></div>
+                  <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                    En cours...
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Analyse des plages horaires pour déterminer les heures creuses
+          </p>
+        </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/ModernButton.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/ModernButton.tsx
@@ -1,0 +1,143 @@
+import { LucideIcon } from 'lucide-react'
+import { ButtonHTMLAttributes, forwardRef } from 'react'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'gradient' | 'glass' | 'tab'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ModernButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  icon?: LucideIcon
+  iconPosition?: 'left' | 'right'
+  isActive?: boolean
+  loading?: boolean
+  fullWidth?: boolean
+}
+
+export const ModernButton = forwardRef<HTMLButtonElement, ModernButtonProps>(
+  (
+    {
+      children,
+      variant = 'primary',
+      size = 'md',
+      icon: Icon,
+      iconPosition = 'left',
+      isActive = false,
+      loading = false,
+      disabled = false,
+      fullWidth = false,
+      className = '',
+      ...props
+    },
+    ref
+  ) => {
+    // Base styles
+    const baseStyles = 'inline-flex items-center justify-center gap-2 font-semibold rounded-lg transition-[background-color,border-color,box-shadow,filter] duration-200 relative overflow-hidden group will-change-[filter]'
+
+    // Size variants
+    const sizeStyles = {
+      sm: 'px-3 py-2 text-sm',
+      md: 'px-3.5 py-2 text-base',
+      lg: 'px-6 py-3 text-lg',
+    }
+
+    // Variant styles with glassmorphism and gradients
+    const variantStyles = {
+      primary: `
+        bg-gradient-to-r from-primary-500 via-primary-600 to-primary-700
+        hover:from-primary-600 hover:via-primary-700 hover:to-primary-800
+        text-white shadow-lg shadow-primary-500/50 dark:shadow-primary-500/30
+        hover:shadow-xl hover:shadow-primary-600/60 dark:hover:shadow-primary-600/40
+        hover:scale-[1.01] active:scale-[0.99]
+        disabled:from-gray-400 disabled:via-gray-500 disabled:to-gray-600
+        disabled:shadow-none disabled:cursor-not-allowed disabled:hover:scale-100
+        before:absolute before:inset-0 before:bg-gradient-to-r before:from-white/0 before:via-white/20 before:to-white/0
+        before:translate-x-[-200%] hover:before:translate-x-[200%] before:transition-transform before:duration-700
+      `,
+      secondary: `
+        bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm
+        border-2 border-gray-200 dark:border-gray-700
+        text-gray-700 dark:text-gray-300
+        hover:bg-white dark:hover:bg-gray-800
+        hover:border-primary-400 dark:hover:border-primary-500
+        hover:shadow-lg hover:shadow-gray-300/50 dark:hover:shadow-gray-900/50
+        hover:scale-[1.01] active:scale-[0.99]
+        disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100
+      `,
+      gradient: `
+        bg-gradient-to-r from-blue-500 via-indigo-600 to-purple-600
+        hover:from-blue-600 hover:via-indigo-700 hover:to-purple-700
+        text-white shadow-md shadow-indigo-500/40 dark:shadow-indigo-500/30
+        hover:shadow-lg hover:shadow-indigo-600/50 dark:hover:shadow-indigo-600/40
+        hover:scale-[1.01] active:scale-[0.99]
+        disabled:from-gray-400 disabled:via-gray-500 disabled:to-gray-600
+        disabled:shadow-none disabled:cursor-not-allowed disabled:hover:scale-100
+        before:absolute before:inset-0 before:bg-gradient-to-r before:from-white/0 before:via-white/30 before:to-white/0
+        before:translate-x-[-200%] hover:before:translate-x-[200%] before:transition-transform before:duration-700
+      `,
+      glass: `
+        bg-white/10 dark:bg-gray-900/10 backdrop-blur-md
+        border border-white/20 dark:border-gray-700/50
+        text-gray-900 dark:text-white
+        hover:bg-white/20 dark:hover:bg-gray-900/20
+        hover:border-white/30 dark:hover:border-gray-600/50
+        hover:shadow-xl hover:shadow-primary-500/20
+        hover:scale-[1.01] active:scale-[0.99]
+        disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100
+      `,
+      tab: `
+        border-2
+        ${isActive
+          ? 'bg-gradient-to-r from-primary-500 to-primary-600 border-primary-600 text-white shadow-sm shadow-primary-500/10 dark:shadow-primary-500/8 hover:shadow-md hover:shadow-primary-500/15 hover:brightness-110 active:brightness-95'
+          : 'bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-primary-400 dark:hover:border-primary-500 hover:bg-gray-50 dark:hover:bg-gray-750 active:bg-gray-100 dark:active:bg-gray-700'
+        }
+        ${isActive ? 'before:absolute before:inset-0 before:bg-gradient-to-r before:from-white/0 before:via-white/20 before:to-white/0 before:translate-x-[-200%] hover:before:translate-x-[200%] before:transition-transform before:duration-700' : ''}
+      `,
+    }
+
+    const widthStyles = fullWidth ? 'w-full' : ''
+
+    const iconSize = size === 'sm' ? 16 : size === 'md' ? 20 : 24
+
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={`
+          ${baseStyles}
+          ${sizeStyles[size]}
+          ${variantStyles[variant]}
+          ${widthStyles}
+          ${className}
+        `}
+        {...props}
+      >
+        {loading && iconPosition === 'left' && (
+          <svg className="animate-spin" width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        )}
+
+        {!loading && Icon && iconPosition === 'left' && (
+          <Icon size={iconSize} className="flex-shrink-0 transition-transform group-hover:scale-110" />
+        )}
+
+        <span className="relative z-10">{children}</span>
+
+        {!loading && Icon && iconPosition === 'right' && (
+          <Icon size={iconSize} className="flex-shrink-0 transition-transform group-hover:translate-x-0.5" />
+        )}
+
+        {loading && iconPosition === 'right' && (
+          <svg className="animate-spin" width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        )}
+      </button>
+    )
+  }
+)
+
+ModernButton.displayName = 'ModernButton'

--- a/apps/web/src/pages/ConsumptionKwh/components/MonthlyHcHp.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/MonthlyHcHp.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceArea } from 'recharts'
+import { Download, ZoomOut } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { ModernButton } from './ModernButton'
+
+interface MonthlyData {
+  month: string
+  hcKwh: number
+  hpKwh: number
+  totalKwh: number
+}
+
+interface YearData {
+  year: string
+  months: MonthlyData[]
+  dataAvailable?: number
+  totalDays?: number
+}
+
+interface MonthlyHcHpProps {
+  monthlyHcHpByYear: YearData[]
+  selectedPDLDetails: any
+  isDarkMode: boolean
+}
+
+export function MonthlyHcHp({ monthlyHcHpByYear, selectedPDLDetails, isDarkMode }: MonthlyHcHpProps) {
+  // Track selected years with a Set (allows multiple selections)
+  // Default to the most recent year (find the highest year value)
+  const [selectedYears, setSelectedYears] = useState<Set<number>>(() => {
+    if (monthlyHcHpByYear.length === 0) return new Set([0])
+
+    // Find index of the most recent year (highest year number)
+    const mostRecentIndex = monthlyHcHpByYear.reduce((maxIdx, current, currentIdx, array) => {
+      return parseInt(current.year) > parseInt(array[maxIdx].year) ? currentIdx : maxIdx
+    }, 0)
+
+    return new Set([mostRecentIndex])
+  })
+
+  // Zoom state
+  const [refAreaLeft, setRefAreaLeft] = useState<string>('')
+  const [refAreaRight, setRefAreaRight] = useState<string>('')
+  const [zoomDomain, setZoomDomain] = useState<{ left: number; right: number } | null>(null)
+
+  // Don't show Monthly HC/HP if:
+  // - No data available
+  // - No offpeak hours configured
+  // - User has BASE pricing (no HC/HP distinction)
+  const pricingOption = selectedPDLDetails?.pricing_option
+  const isBasePricing = pricingOption === 'BASE'
+
+  if (monthlyHcHpByYear.length === 0 || !selectedPDLDetails?.offpeak_hours || isBasePricing) {
+    return null
+  }
+
+  const toggleYearSelection = (index: number) => {
+    const newSelection = new Set(selectedYears)
+    if (newSelection.has(index)) {
+      // Don't allow deselecting the last selected year
+      if (newSelection.size > 1) {
+        newSelection.delete(index)
+      }
+    } else {
+      newSelection.add(index)
+    }
+    setSelectedYears(newSelection)
+  }
+
+  const handleExport = () => {
+    const selectedData = Array.from(selectedYears)
+      .map(index => monthlyHcHpByYear[index])
+      .sort((a, b) => a.year.localeCompare(b.year)) // Sort by year ascending
+    const jsonData = JSON.stringify(selectedData, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    const yearLabels = selectedData.map(d => d.year).join(', ')
+    toast.success(`Données HC/HP de ${yearLabels} copiées dans le presse-papier`)
+  }
+
+  const zoomOut = () => {
+    setZoomDomain(null)
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  const zoom = () => {
+    if (!refAreaLeft || !refAreaRight) return
+
+    // Get indices
+    let left = chartData.findIndex(item => item.month === refAreaLeft)
+    let right = chartData.findIndex(item => item.month === refAreaRight)
+
+    if (left === right || left === -1 || right === -1) {
+      setRefAreaLeft('')
+      setRefAreaRight('')
+      return
+    }
+
+    // Swap if needed
+    if (left > right) [left, right] = [right, left]
+
+    setZoomDomain({ left, right })
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  // Prepare chart data with all selected years
+  const chartData = (() => {
+    const selectedYearsData = Array.from(selectedYears)
+      .map(index => monthlyHcHpByYear[index])
+      .sort((a, b) => a.year.localeCompare(b.year)) // Sort by year ascending (2024 before 2025)
+
+    // Create a map of all months
+    const monthsMap = new Map<string, any>()
+
+    selectedYearsData.forEach((yearData) => {
+      yearData.months.forEach(monthData => {
+        const monthKey = monthData.month.split(' ')[0] // Extract month name (e.g., "Jan")
+
+        if (!monthsMap.has(monthKey)) {
+          monthsMap.set(monthKey, { month: monthKey })
+        }
+
+        const entry = monthsMap.get(monthKey)!
+        // Add data for this year with index suffix
+        entry[`hc_${yearData.year}`] = monthData.hcKwh
+        entry[`hp_${yearData.year}`] = monthData.hpKwh
+      })
+    })
+
+    // Convert to array and ensure proper month order
+    const monthOrder = ['jan', 'fév', 'mar', 'avr', 'mai', 'jun', 'jul', 'aoû', 'sep', 'oct', 'nov', 'déc']
+    return Array.from(monthsMap.values()).sort((a, b) => {
+      const aIndex = monthOrder.findIndex(m => a.month.toLowerCase().startsWith(m))
+      const bIndex = monthOrder.findIndex(m => b.month.toLowerCase().startsWith(m))
+      return aIndex - bIndex
+    })
+  })()
+
+  const selectedYearsData = Array.from(selectedYears)
+    .map(index => monthlyHcHpByYear[index])
+    .sort((a, b) => a.year.localeCompare(b.year)) // Sort by year ascending for display
+
+  // Get display data based on zoom
+  const displayData = zoomDomain
+    ? chartData.slice(zoomDomain.left, zoomDomain.right + 1)
+    : chartData
+
+  return (
+    <div className="mt-8">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+        Consommation HC/HP par mois
+      </h3>
+
+      {/* Tabs and buttons - responsive layout */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        {/* Tabs on the left - Allow multiple selection */}
+        <div className="flex gap-2 flex-1 overflow-x-auto overflow-y-hidden py-3 px-2 no-scrollbar">
+          {monthlyHcHpByYear.map((yearData, _idx) => {
+            const isSelected = selectedYears.has(_idx)
+            return (
+              <ModernButton
+                key={yearData.year}
+                variant="tab"
+                size="md"
+                isActive={isSelected}
+                onClick={() => toggleYearSelection(_idx)}
+                className="flex-1 min-w-[80px]"
+              >
+                {yearData.year}
+              </ModernButton>
+            )
+          })}
+        </div>
+
+        {/* Action buttons on the right */}
+        <div className="flex gap-2">
+          {zoomDomain && (
+            <ModernButton
+              variant="gradient"
+              size="sm"
+              icon={ZoomOut}
+              iconPosition="left"
+              onClick={zoomOut}
+              title="Réinitialiser le zoom"
+              className="bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700"
+            >
+              Réinitialiser
+            </ModernButton>
+          )}
+          <ModernButton
+            variant="gradient"
+            size="sm"
+            icon={Download}
+            iconPosition="left"
+            onClick={handleExport}
+          >
+            Export JSON
+          </ModernButton>
+        </div>
+      </div>
+
+      {/* Display selected years chart */}
+      <div className="bg-gray-50 dark:bg-gray-700/30 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
+        {/* Show data availability warnings for selected years */}
+        {selectedYearsData.some(year => year.dataAvailable !== undefined && year.dataAvailable < 350) && (
+          <div className="mb-4 space-y-2">
+            {selectedYearsData
+              .filter(year => year.dataAvailable !== undefined && year.dataAvailable < 350)
+              .map(year => (
+                <div key={year.year} className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <p className="text-sm text-amber-800 dark:text-amber-200">
+                    <strong>⚠️ {year.year} - Données partielles :</strong> {year.dataAvailable} jours de données disponibles sur 365 jours pour cette période glissante.
+                    {year.dataAvailable! < 100 && ' Les valeurs affichées peuvent être significativement incomplètes.'}
+                  </p>
+                </div>
+              ))
+            }
+          </div>
+        )}
+
+        <ResponsiveContainer width="100%" height={400}>
+          <BarChart
+            data={displayData}
+            onMouseDown={(e) => e && e.activeLabel && setRefAreaLeft(e.activeLabel)}
+            onMouseMove={(e) => refAreaLeft && e && e.activeLabel && setRefAreaRight(e.activeLabel)}
+            onMouseUp={zoom}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#9CA3AF" opacity={0.3} />
+            <XAxis
+              dataKey="month"
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              tick={{ fill: isDarkMode ? '#FFFFFF' : '#6B7280', fontSize: 12 }}
+            />
+            <YAxis
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              tick={{ fill: isDarkMode ? '#FFFFFF' : '#6B7280', fontSize: 12 }}
+              label={{ value: 'Consommation (kWh)', angle: -90, position: 'insideLeft', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+            />
+            <Tooltip
+              cursor={{ fill: 'rgba(59, 130, 246, 0.15)' }}
+              contentStyle={{
+                backgroundColor: '#1F2937',
+                border: '1px solid #374151',
+                borderRadius: '8px',
+                color: '#F9FAFB'
+              }}
+              formatter={(value: number) => value.toLocaleString('fr-FR', { maximumFractionDigits: 2 }) + ' kWh'}
+            />
+            <Legend />
+            {/* Dynamically create bars for each selected year */}
+            {selectedYearsData.map((yearData, _yearIndex) => {
+              // Define colors for HC and HP for each year with transparency for overlay effect
+              const hcColors = [
+                'rgba(59, 130, 246, 0.7)',   // blue
+                'rgba(147, 197, 253, 0.7)',  // light blue
+                'rgba(96, 165, 250, 0.7)',   // sky blue
+                'rgba(37, 99, 235, 0.7)'     // dark blue
+              ]
+              const hpColors = [
+                'rgba(249, 115, 22, 0.7)',   // orange
+                'rgba(253, 186, 116, 0.7)',  // light orange
+                'rgba(251, 146, 60, 0.7)',   // amber
+                'rgba(234, 88, 12, 0.7)'     // dark orange
+              ]
+
+              return (
+                <React.Fragment key={yearData.year}>
+                  <Bar
+                    dataKey={`hc_${yearData.year}`}
+                    name={`HC ${yearData.year}`}
+                    fill={hcColors[_yearIndex % hcColors.length]}
+                  />
+                  <Bar
+                    dataKey={`hp_${yearData.year}`}
+                    name={`HP ${yearData.year}`}
+                    fill={hpColors[_yearIndex % hpColors.length]}
+                  />
+                </React.Fragment>
+              )
+            })}
+
+            {/* Selection area for zooming */}
+            {refAreaLeft && refAreaRight && (
+              <ReferenceArea
+                x1={refAreaLeft}
+                x2={refAreaRight}
+                strokeOpacity={0.3}
+                fill={isDarkMode ? "#6366f1" : "#818cf8"}
+                fillOpacity={0.3}
+              />
+            )}
+          </BarChart>
+        </ResponsiveContainer>
+
+        {/* Zoom instruction */}
+        {!zoomDomain && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
+            💡 Cliquez et glissez sur le graphique pour zoomer sur une période
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/PDLSelector.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/PDLSelector.tsx
@@ -1,0 +1,128 @@
+import { Download, Settings, Lock } from 'lucide-react'
+import type { PDL } from '@/types/api'
+import { useIsDemo } from '@/hooks/useIsDemo'
+import { ModernButton } from './ModernButton'
+
+interface PDLSelectorProps {
+  pdls: PDL[]
+  activePdls: PDL[]
+  selectedPDL: string
+  selectedPDLDetails: PDL | undefined
+  onPDLSelect: (value: string) => void
+  onFetchData: () => void
+  isLoading: boolean
+  isLoadingDetailed: boolean
+  dataLimitWarning: string | null
+  children?: React.ReactNode
+}
+
+export function PDLSelector({
+  activePdls,
+  selectedPDL,
+  onPDLSelect,
+  onFetchData,
+  isLoading,
+  isLoadingDetailed,
+  dataLimitWarning,
+  children
+}: PDLSelectorProps) {
+  const isDemo = useIsDemo()
+
+  return (
+    <div className="card">
+      {/* Configuration Header */}
+      <div className="flex items-center gap-2 mb-6">
+        <Settings className="text-primary-600 dark:text-primary-400" size={20} />
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Configuration</h2>
+      </div>
+
+      <div className="space-y-6">
+        {/* PDL Selection - Only show if more than one active PDL */}
+        {activePdls.length > 1 && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Point de Livraison (PDL)
+            </label>
+            <select
+              value={selectedPDL}
+              onChange={(e) => onPDLSelect(e.target.value)}
+              disabled={isLoading || isLoadingDetailed}
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {activePdls.map((pdl: PDL) => (
+                <option key={pdl.usage_point_id} value={pdl.usage_point_id}>
+                  {pdl.name || pdl.usage_point_id}
+                </option>
+              ))}
+            </select>
+
+            {/* Warning if PDL has limited data */}
+            {dataLimitWarning && (
+              <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center gap-2">
+                <span className="text-blue-600 dark:text-blue-400 text-lg flex-shrink-0">ℹ️</span>
+                <p className="text-sm text-blue-800 dark:text-blue-200">
+                  {dataLimitWarning}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* No active PDL message */}
+        {activePdls.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            Aucun PDL actif disponible. Veuillez en ajouter un depuis votre{' '}
+            <a href="/dashboard" className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 underline">
+              tableau de bord
+            </a>.
+          </div>
+        )}
+
+        {/* Warning if PDL has limited data - Show for single PDL too */}
+        {activePdls.length === 1 && dataLimitWarning && (
+          <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center gap-2">
+            <span className="text-blue-600 dark:text-blue-400 text-lg flex-shrink-0">ℹ️</span>
+            <p className="text-sm text-blue-800 dark:text-blue-200">
+              {dataLimitWarning}
+            </p>
+          </div>
+        )}
+
+        {/* Fetch Button - Always show if there are active PDLs */}
+        {activePdls.length > 0 && (
+          <>
+            <ModernButton
+              variant="primary"
+              size="lg"
+              fullWidth
+              onClick={onFetchData}
+              disabled={!selectedPDL || isLoading || isLoadingDetailed || isDemo}
+              icon={isDemo ? Lock : Download}
+              iconPosition="left"
+              loading={isLoading || isLoadingDetailed}
+            >
+              {isLoading || isLoadingDetailed
+                ? 'Récupération en cours...'
+                : isDemo
+                  ? 'Récupération bloquée en mode démo'
+                  : 'Récupérer l\'historique'
+              }
+            </ModernButton>
+
+            {isDemo && (
+              <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                <p className="text-sm text-amber-800 dark:text-amber-200">
+                  <strong>Mode Démo :</strong> Le compte démo dispose déjà de 3 ans de données fictives.
+                  La récupération depuis l'API Enedis est désactivée.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Children (LoadingProgress) */}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/PowerPeaks.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/PowerPeaks.tsx
@@ -1,0 +1,313 @@
+import { useState } from 'react'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine, ReferenceArea } from 'recharts'
+import { Download, ZoomOut } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { ModernButton } from './ModernButton'
+
+interface PowerData {
+  label: string
+  data: Array<{
+    date: string
+    power: number
+    time: string
+    year: string
+  }>
+}
+
+interface PowerPeaksProps {
+  powerByYearData: PowerData[]
+  selectedPDLDetails: any
+  isDarkMode: boolean
+}
+
+export function PowerPeaks({
+  powerByYearData,
+  selectedPDLDetails,
+  isDarkMode
+}: PowerPeaksProps) {
+  // Track selected years with a Set (allows multiple selections)
+  // Default to the most recent year (last index in the array)
+  const [selectedYears, setSelectedYears] = useState<Set<number>>(
+    new Set([powerByYearData.length > 0 ? powerByYearData.length - 1 : 0])
+  )
+
+  // Zoom state
+  const [refAreaLeft, setRefAreaLeft] = useState<string>('')
+  const [refAreaRight, setRefAreaRight] = useState<string>('')
+  const [zoomDomain, setZoomDomain] = useState<{ left: number; right: number } | null>(null)
+
+  const toggleYearSelection = (index: number) => {
+    const newSelection = new Set(selectedYears)
+    if (newSelection.has(index)) {
+      // Don't allow deselecting the last selected year
+      if (newSelection.size > 1) {
+        newSelection.delete(index)
+      }
+    } else {
+      newSelection.add(index)
+    }
+    setSelectedYears(newSelection)
+  }
+
+  const handleExport = () => {
+    const selectedData = Array.from(selectedYears)
+      .map(index => powerByYearData[index])
+      .sort((a, b) => b.label.localeCompare(a.label))
+    const jsonData = JSON.stringify(selectedData, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    const yearLabels = selectedData.map(d => d.label).join(', ')
+    toast.success(`Données de puissance de ${yearLabels} copiées dans le presse-papier`)
+  }
+
+  const zoomOut = () => {
+    setZoomDomain(null)
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  const zoom = () => {
+    if (!refAreaLeft || !refAreaRight) return
+
+    // Get indices
+    let left = chartData.findIndex(item => item.date === refAreaLeft)
+    let right = chartData.findIndex(item => item.date === refAreaRight)
+
+    if (left === right || left === -1 || right === -1) {
+      setRefAreaLeft('')
+      setRefAreaRight('')
+      return
+    }
+
+    // Swap if needed
+    if (left > right) [left, right] = [right, left]
+
+    setZoomDomain({ left, right })
+    setRefAreaLeft('')
+    setRefAreaRight('')
+  }
+
+  if (powerByYearData.length === 0) {
+    return null
+  }
+
+  // Prepare chart data with all selected years
+  const chartData = (() => {
+    const selectedYearsData = Array.from(selectedYears)
+      .map(index => powerByYearData[index])
+      .sort((a, b) => b.label.localeCompare(a.label)) // Sort by year descending
+
+    // Create a map using normalized dates (MM-DD) to overlay years
+    const datesMap = new Map<string, any>()
+
+    selectedYearsData.forEach((yearData) => {
+      yearData.data.forEach(dayData => {
+        const date = new Date(dayData.date)
+        // Normalize to same year to overlay data (use month-day only)
+        const normalizedKey = `${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+
+        if (!datesMap.has(normalizedKey)) {
+          // Store a reference date for display (using year 2000 as base)
+          const displayDate = new Date(2000, date.getMonth(), date.getDate())
+          datesMap.set(normalizedKey, {
+            date: displayDate.toISOString().split('T')[0],
+            monthDay: normalizedKey
+          })
+        }
+
+        const entry = datesMap.get(normalizedKey)!
+        // Add data for this year
+        entry[`power_${yearData.label}`] = dayData.power
+        entry[`time_${yearData.label}`] = dayData.time
+        entry[`year_${yearData.label}`] = date.getFullYear()
+      })
+    })
+
+    // Convert to array and sort by month-day
+    return Array.from(datesMap.values()).sort((a, b) => {
+      const [aMonth, aDay] = a.monthDay.split('-').map(Number)
+      const [bMonth, bDay] = b.monthDay.split('-').map(Number)
+      if (aMonth !== bMonth) return aMonth - bMonth
+      return aDay - bDay
+    })
+  })()
+
+  const selectedYearsData = Array.from(selectedYears)
+    .map(index => powerByYearData[index])
+    .sort((a, b) => b.label.localeCompare(a.label))
+
+  const colors = ['#EF4444', '#F59E0B', '#10B981', '#8B5CF6', '#EC4899', '#06B6D4']
+
+  // Get display data based on zoom
+  const displayData = zoomDomain
+    ? chartData.slice(zoomDomain.left, zoomDomain.right + 1)
+    : chartData
+
+  return (
+    <div className="mt-6">
+      {/* Tabs and buttons - responsive layout */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        {/* Tabs on the left - Allow multiple selection */}
+        <div className="flex gap-2 flex-1 overflow-x-auto overflow-y-hidden py-3 px-2 no-scrollbar">
+          {[...powerByYearData].reverse().map((data, idx) => {
+            const originalIndex = powerByYearData.length - 1 - idx
+            const isSelected = selectedYears.has(originalIndex)
+            return (
+              <ModernButton
+                key={data.label}
+                variant="tab"
+                size="md"
+                isActive={isSelected}
+                onClick={() => toggleYearSelection(originalIndex)}
+                className="flex-1 min-w-[100px]"
+              >
+                {data.label}
+              </ModernButton>
+            )
+          })}
+        </div>
+
+        {/* Action buttons on the right */}
+        <div className="flex gap-2">
+          {zoomDomain && (
+            <ModernButton
+              variant="gradient"
+              size="sm"
+              icon={ZoomOut}
+              iconPosition="left"
+              onClick={zoomOut}
+              title="Réinitialiser le zoom"
+              className="bg-gradient-to-r from-purple-500 to-pink-600 hover:from-purple-600 hover:to-pink-700"
+            >
+              Réinitialiser
+            </ModernButton>
+          )}
+          <ModernButton
+            variant="gradient"
+            size="sm"
+            icon={Download}
+            iconPosition="left"
+            onClick={handleExport}
+          >
+            Export JSON
+          </ModernButton>
+        </div>
+      </div>
+
+      {/* Display selected years graph */}
+      <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
+        <ResponsiveContainer width="100%" height={350}>
+          <LineChart
+            data={displayData}
+            onMouseDown={(e) => e && e.activeLabel && setRefAreaLeft(e.activeLabel)}
+            onMouseMove={(e) => refAreaLeft && e && e.activeLabel && setRefAreaRight(e.activeLabel)}
+            onMouseUp={zoom}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#9CA3AF" opacity={0.3} />
+            <XAxis
+              dataKey="date"
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '11px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+              tickFormatter={(value) => {
+                const date = new Date(value)
+                return `${date.getDate()}/${date.getMonth() + 1}`
+              }}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '14px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+              label={{ value: 'Puissance (kW)', angle: -90, position: 'insideLeft', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+              domain={[0, 'auto']}
+            />
+            <Tooltip
+              cursor={{ stroke: colors[0], strokeWidth: 2 }}
+              contentStyle={{
+                backgroundColor: '#1F2937',
+                border: '1px solid #374151',
+                borderRadius: '8px',
+                color: '#F9FAFB'
+              }}
+              formatter={(value: number, name: string, props: any) => {
+                // Extract year from the dataKey (e.g., "power_2025")
+                const year = name.replace('Puissance max ', '')
+                const timeKey = `time_${year}`
+                const yearKey = `year_${year}`
+                const time = props.payload?.[timeKey]
+                const actualYear = props.payload?.[yearKey]
+                if (time && actualYear) {
+                  return [`${value.toFixed(2)} kW à ${time} (${actualYear})`, name]
+                }
+                return [`${value.toFixed(2)} kW`, name]
+              }}
+              labelFormatter={(label) => {
+                const date = new Date(label)
+                return `${date.getDate()} ${date.toLocaleDateString('fr-FR', { month: 'short' })}`
+              }}
+            />
+            <Legend />
+
+            {/* Reference line for subscribed power */}
+            {selectedPDLDetails?.subscribed_power && (
+              <ReferenceLine
+                y={selectedPDLDetails.subscribed_power}
+                stroke="#8B5CF6"
+                strokeWidth={2}
+                strokeDasharray="5 5"
+                label={{
+                  value: `Puissance souscrite: ${selectedPDLDetails.subscribed_power} kVA`,
+                  position: 'insideTopRight',
+                  fill: '#8B5CF6',
+                  fontSize: 12
+                }}
+              />
+            )}
+
+            {/* Dynamically create lines for each selected year */}
+            {selectedYearsData.map((yearData, index) => (
+              <Line
+                key={yearData.label}
+                type="monotone"
+                dataKey={`power_${yearData.label}`}
+                stroke={colors[index % colors.length]}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 6 }}
+                name={`Puissance max ${yearData.label}`}
+              />
+            ))}
+
+            {/* Selection area for zooming */}
+            {refAreaLeft && refAreaRight && (
+              <ReferenceArea
+                x1={refAreaLeft}
+                x2={refAreaRight}
+                strokeOpacity={0.3}
+                fill={isDarkMode ? "#6366f1" : "#818cf8"}
+                fillOpacity={0.3}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+
+        {/* Zoom instruction */}
+        {!zoomDomain && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
+            💡 Cliquez et glissez sur le graphique pour zoomer sur une période
+          </p>
+        )}
+      </div>
+
+      {/* Info message */}
+      <div className="mt-4 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+        <p className="text-sm text-amber-800 dark:text-amber-200">
+          <strong>ℹ️ Note :</strong> Ces graphiques montrent les pics de puissance maximale atteints chaque jour sur les 3 dernières années.
+          {selectedPDLDetails?.subscribed_power && (
+            <> La ligne violette en pointillés indique votre puissance souscrite ({selectedPDLDetails.subscribed_power} kVA).
+            Le compteur Linky autorise des dépassements temporaires de cette limite, donc un pic ponctuel au-dessus de cette ligne ne provoquera pas nécessairement de disjonction.
+            Cependant, si les pics dépassent régulièrement ou de manière prolongée cette ligne, vous risquez de disjoncter.</>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/YearlyConsumption.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/YearlyConsumption.tsx
@@ -1,0 +1,82 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { Download } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { ModernButton } from './ModernButton'
+
+interface YearlyConsumptionProps {
+  chartData: {
+    byYear: any[]
+    byMonthComparison: any[]
+    years: string[]
+  }
+  consumptionData: any
+  isDarkMode: boolean
+}
+
+export function YearlyConsumption({ chartData, isDarkMode }: YearlyConsumptionProps) {
+  const handleExportMonthly = () => {
+    const jsonData = JSON.stringify(chartData.byMonthComparison, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    toast.success('Données mensuelles copiées dans le presse-papier')
+  }
+
+  return (
+    <div>
+      {/* Monthly Comparison Chart */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Comparaison mensuelle par année
+        </h3>
+        <ModernButton
+          variant="gradient"
+          size="sm"
+          icon={Download}
+          iconPosition="left"
+          onClick={handleExportMonthly}
+        >
+          Export JSON
+        </ModernButton>
+      </div>
+      <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
+        <ResponsiveContainer width="100%" height={350}>
+          <BarChart data={chartData.byMonthComparison}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#9CA3AF" opacity={0.3} />
+            <XAxis
+              dataKey="monthLabel"
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '14px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+            />
+            <YAxis
+              stroke={isDarkMode ? "#FFFFFF" : "#6B7280"}
+              style={{ fontSize: '14px', fill: isDarkMode ? '#FFFFFF' : '#6B7280' }}
+              tickFormatter={(value) => `${(value / 1000).toFixed(0)} kWh`}
+            />
+            <Tooltip
+              cursor={{ fill: 'rgba(59, 130, 246, 0.1)' }}
+              contentStyle={{
+                backgroundColor: '#1F2937',
+                border: '1px solid #374151',
+                borderRadius: '8px',
+                color: '#F9FAFB'
+              }}
+              formatter={(value: number) => [`${(value / 1000).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh`, 'Consommation']}
+            />
+            <Legend />
+            {chartData.years.map((year, index) => {
+              const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899']
+              return (
+                <Bar
+                  key={year}
+                  dataKey={year}
+                  fill={colors[index % colors.length]}
+                  radius={[4, 4, 0, 0]}
+                  name={year}
+                />
+              )
+            })}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/components/YearlyStatCards.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/components/YearlyStatCards.tsx
@@ -1,0 +1,156 @@
+import { Download } from 'lucide-react'
+import toast from 'react-hot-toast'
+
+interface YearlyStatCardsProps {
+  chartData: {
+    byYear: any[]
+    unit?: string
+  }
+  consumptionData: any
+}
+
+export function YearlyStatCards({ chartData, consumptionData }: YearlyStatCardsProps) {
+  const handleExportYear = (yearData: any) => {
+    const intervalLength = consumptionData?.meter_reading?.reading_type?.interval_length || 'P1D'
+    const unit = consumptionData?.meter_reading?.reading_type?.unit || 'W'
+
+    const startDateFormatted = yearData.startDate.toLocaleDateString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    })
+    const endDateFormatted = yearData.endDate.toLocaleDateString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    })
+
+    // Parse interval to duration in hours
+    const parseIntervalToDurationInHours = (interval: string): number => {
+      const match = interval.match(/^P(\d+)([DHM])$/)
+      if (!match) return 1
+      const value = parseInt(match[1], 10)
+      const unit = match[2]
+      switch (unit) {
+        case 'D': return 1 // Daily values are already total energy
+        case 'H': return value
+        case 'M': return value / 60
+        default: return 1
+      }
+    }
+
+    // Get interval multiplier for this export
+    const getIntervalMultiplier = (interval: string, valueUnit: string): number => {
+      if (valueUnit === 'Wh' || valueUnit === 'WH') return 1
+      if (valueUnit === 'W') {
+        return parseIntervalToDurationInHours(interval)
+      }
+      return 1
+    }
+
+    const intervalMultiplier = getIntervalMultiplier(intervalLength, unit)
+
+    // Filter interval readings for this year and apply multiplier
+    const yearReadings = consumptionData?.meter_reading?.interval_reading?.filter((reading: any) => {
+      const date = reading.date?.split('T')[0] || reading.date
+      return date && date.startsWith(yearData.year)
+    }).map((reading: any) => ({
+      date: reading.date?.split('T')[0] || reading.date,
+      value_raw: parseFloat(reading.value || 0),
+      value_wh: parseFloat(reading.value || 0) * intervalMultiplier
+    })) || []
+
+    const jsonData = JSON.stringify({
+      year: yearData.year,
+      startDate: startDateFormatted,
+      endDate: endDateFormatted,
+      consommation_kwh: (yearData.consommation / 1000),
+      consommation_wh: yearData.consommation,
+      unit_raw: unit,
+      interval_length: intervalLength,
+      interval_multiplier: intervalMultiplier,
+      interval_readings: yearReadings,
+      total_readings: yearReadings.length
+    }, null, 2)
+
+    navigator.clipboard.writeText(jsonData)
+    toast.success(`Données ${yearData.year} copiées (${yearReadings.length} lectures)`)
+  }
+
+  const handleExportAll = () => {
+    const jsonData = JSON.stringify(chartData.byYear, null, 2)
+    navigator.clipboard.writeText(jsonData)
+    toast.success('Données copiées dans le presse-papier')
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Consommation par année
+        </h3>
+        <button
+          onClick={handleExportAll}
+          className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white rounded-lg shadow-sm hover:shadow-md transition-all duration-200"
+        >
+          <Download size={16} className="flex-shrink-0" />
+          <span>Export JSON</span>
+        </button>
+      </div>
+
+      <div className="overflow-x-auto pb-2">
+        <div className={`grid gap-3 grid-cols-1 sm:grid-cols-2 ${
+          chartData.byYear.length === 3
+            ? 'lg:grid-cols-3'
+            : chartData.byYear.length >= 4
+              ? 'lg:grid-cols-3 xl:grid-cols-4'
+              : 'lg:grid-cols-2'
+        }`}>
+          {chartData.byYear.map((yearData) => {
+            const startDateFormatted = yearData.startDate.toLocaleDateString('fr-FR', {
+              day: '2-digit',
+              month: '2-digit',
+              year: 'numeric'
+            })
+            const endDateFormatted = yearData.endDate.toLocaleDateString('fr-FR', {
+              day: '2-digit',
+              month: '2-digit',
+              year: 'numeric'
+            })
+
+            return (
+              <div
+                key={yearData.year}
+                className="bg-gray-50 dark:bg-gray-700/30 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
+              >
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-lg font-bold text-gray-900 dark:text-white">
+                      {yearData.year}
+                    </p>
+                    <button
+                      onClick={() => handleExportYear(yearData)}
+                      className="p-1.5 bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white rounded shadow-sm hover:shadow-md transition-all duration-200"
+                    >
+                      <Download size={14} />
+                    </button>
+                  </div>
+
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {startDateFormatted} - {endDateFormatted}
+                  </p>
+
+                  <div className="mt-2">
+                    <p className="text-xl font-bold text-blue-600 dark:text-blue-400">
+                      {(yearData.consommation / 1000).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} kWh
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionCalcs.ts
+++ b/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionCalcs.ts
@@ -1,0 +1,680 @@
+import { useMemo, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { parseOffpeakHours, isOffpeakTime } from '@/utils/offpeakHours'
+import type { ConsumptionAPIResponse, MaxPowerAPIResponse, DetailAPIResponse } from '../types/consumption.types'
+
+interface UseConsumptionCalcsProps {
+  consumptionData: ConsumptionAPIResponse | null
+  maxPowerData: MaxPowerAPIResponse | null
+  detailData: DetailAPIResponse | null
+  selectedPDL: string | null
+  selectedPDLDetails: any
+  hcHpCalculationTrigger: number
+  detailDateRange: { start: string; end: string } | null
+}
+
+export function useConsumptionCalcs({
+  consumptionData,
+  maxPowerData,
+  detailData,
+  selectedPDL,
+  selectedPDLDetails,
+  hcHpCalculationTrigger,
+  detailDateRange: _detailDateRange // Not used anymore - show all cached data for fluid navigation
+}: UseConsumptionCalcsProps) {
+  const queryClient = useQueryClient()
+  const [selectedPowerYear, setSelectedPowerYear] = useState(0)
+
+  // Process consumption data for charts
+  const chartData = useMemo(() => {
+    if (!consumptionData?.meter_reading?.interval_reading) {
+      return { byYear: [], byMonth: [], byMonthComparison: [], total: 0, years: [], unit: 'W' }
+    }
+
+    const readings = consumptionData.meter_reading.interval_reading
+    const unit = consumptionData.meter_reading.reading_type?.unit || 'W'
+    const intervalLength = consumptionData.meter_reading.reading_type?.interval_length || 'P1D'
+
+    // Parse interval length to determine how to handle the values
+    const parseIntervalToDurationInHours = (interval: string): number => {
+      const match = interval.match(/^P(\d+)([DHM])$/)
+      if (!match) return 1
+
+      const value = parseInt(match[1], 10)
+      const unitType = match[2]
+
+      switch (unitType) {
+        case 'D': return 1 // Daily values are already total energy
+        case 'H': return value
+        case 'M': return value / 60
+        default: return 1
+      }
+    }
+
+    const getIntervalMultiplier = (interval: string, valueUnit: string): number => {
+      if (valueUnit === 'Wh' || valueUnit === 'WH') return 1
+      if (valueUnit === 'W') {
+        return parseIntervalToDurationInHours(interval)
+      }
+      return 1
+    }
+
+    const intervalMultiplier = getIntervalMultiplier(intervalLength, unit)
+
+    const monthlyData: Record<string, number> = {}
+    const monthYearData: Record<string, Record<string, number>> = {}
+    let totalConsumption = 0
+
+    // Find the most recent date in the actual data
+    let mostRecentDate = new Date(0)
+    readings.forEach((reading: any) => {
+      const dateStr = reading.date?.split('T')[0] || reading.date
+      if (dateStr) {
+        const readingDate = new Date(dateStr)
+        if (readingDate > mostRecentDate) {
+          mostRecentDate = readingDate
+        }
+      }
+    })
+
+    // Define 365-day periods (sliding windows)
+    const period1End = mostRecentDate
+    const period1Start = new Date(mostRecentDate.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const period2End = new Date(mostRecentDate.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const period2Start = new Date(mostRecentDate.getTime() - 730 * 24 * 60 * 60 * 1000)
+    const period3End = new Date(mostRecentDate.getTime() - 730 * 24 * 60 * 60 * 1000)
+    const period3Start = new Date(mostRecentDate.getTime() - 1095 * 24 * 60 * 60 * 1000)
+
+    const periods = [
+      {
+        label: String(period1End.getFullYear()),
+        startDaysAgo: 0,
+        endDaysAgo: 365,
+        startDate: period1Start,
+        endDate: period1End
+      },
+      {
+        label: String(period2End.getFullYear()),
+        startDaysAgo: 365,
+        endDaysAgo: 730,
+        startDate: period2Start,
+        endDate: period2End
+      },
+      {
+        label: String(period3End.getFullYear()),
+        startDaysAgo: 730,
+        endDaysAgo: 1095,
+        startDate: period3Start,
+        endDate: period3End
+      }
+    ]
+
+    // Aggregate by 365-day periods
+    const periodData: Record<string, { value: number, startDate: Date, endDate: Date }> = {}
+    const periodMonthlyData: Record<string, Record<string, number>> = {}
+
+    readings.forEach((reading: any) => {
+      const rawValue = parseFloat(reading.value || 0)
+      const dateStr = reading.date?.split('T')[0] || reading.date
+
+      if (!dateStr || isNaN(rawValue)) return
+
+      const value = rawValue * intervalMultiplier
+      const readingDate = new Date(dateStr)
+      const year = dateStr.substring(0, 4)
+      const month = dateStr.substring(0, 7)
+      const monthOnly = dateStr.substring(5, 7)
+
+      // Find which period this reading belongs to
+      periods.forEach(period => {
+        if (readingDate >= period.startDate && readingDate <= period.endDate) {
+          if (!periodData[period.label]) {
+            periodData[period.label] = {
+              value: 0,
+              startDate: period.startDate,
+              endDate: period.endDate
+            }
+          }
+          periodData[period.label].value += value
+
+          // Aggregate monthly data for each period
+          if (!periodMonthlyData[period.label]) {
+            periodMonthlyData[period.label] = {}
+          }
+          periodMonthlyData[period.label][month] = (periodMonthlyData[period.label][month] || 0) + value
+        }
+      })
+
+      // Aggregate by month
+      monthlyData[month] = (monthlyData[month] || 0) + value
+
+      // Aggregate by month for year comparison
+      if (!monthYearData[monthOnly]) {
+        monthYearData[monthOnly] = {}
+      }
+      monthYearData[monthOnly][year] = (monthYearData[monthOnly][year] || 0) + value
+
+      totalConsumption += value
+    })
+
+    // Convert to chart format
+    const byYear = Object.entries(periodData)
+      .map(([label, data]) => ({
+        year: label,
+        consumption: Math.round(data.value),
+        consommation: Math.round(data.value),
+        startDate: data.startDate,
+        endDate: data.endDate
+      }))
+      .reverse()
+
+    // Get all years for compatibility
+    const years = Object.keys(monthYearData).length > 0
+      ? Object.keys(readings.reduce((acc: any, r: any) => {
+          const year = r.date?.substring(0, 4)
+          if (year) acc[year] = true
+          return acc
+        }, {})).sort()
+      : []
+
+    const byMonth = Object.entries(monthlyData)
+      .map(([month, value]) => ({
+        month,
+        monthLabel: new Date(month + '-01').toLocaleDateString('fr-FR', { year: 'numeric', month: 'short' }),
+        consumption: Math.round(value),
+        consommation: Math.round(value),
+      }))
+      .sort((a, b) => a.month.localeCompare(b.month))
+
+    // Monthly comparison across years
+    const monthNames = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
+    const monthLabels = ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Jun', 'Jul', 'Aoû', 'Sep', 'Oct', 'Nov', 'Déc']
+
+    const byMonthComparison = monthNames.map((monthNum, idx) => {
+      const row: any = {
+        month: monthNum,
+        monthLabel: monthLabels[idx],
+      }
+
+      years.forEach(year => {
+        const value = monthYearData[monthNum]?.[year] || 0
+        row[year] = Math.round(value)
+      })
+
+      return row
+    })
+
+    // Create years array for AnnualCurve multi-select
+    const yearsByPeriod = periods.map(period => {
+      const periodMonths = periodMonthlyData[period.label] || {}
+      const byMonth = Object.entries(periodMonths)
+        .map(([month, value]) => ({
+          month,
+          monthLabel: new Date(month + '-01').toLocaleDateString('fr-FR', { year: 'numeric', month: 'short' }),
+          consumption: Math.round(value),
+          consommation: Math.round(value),
+        }))
+        .sort((a, b) => a.month.localeCompare(b.month))
+
+      return {
+        label: period.label,
+        byMonth
+      }
+    }).reverse()
+
+    return {
+      byYear,
+      byMonth,
+      byMonthComparison,
+      total: Math.round(totalConsumption),
+      years,
+      yearsByPeriod,
+      unit,
+    }
+  }, [consumptionData])
+
+  // Process max power data by year
+  const powerByYearData = useMemo(() => {
+    if (!maxPowerData?.meter_reading?.interval_reading) {
+      return []
+    }
+
+    const readings = maxPowerData.meter_reading.interval_reading
+
+    // Get the most recent date in the data
+    let mostRecentDate = new Date(0)
+    readings.forEach((reading: any) => {
+      const dateStr = reading.date?.split('T')[0] || reading.date
+      if (dateStr) {
+        const readingDate = new Date(dateStr)
+        if (readingDate > mostRecentDate) {
+          mostRecentDate = readingDate
+        }
+      }
+    })
+
+    // Define 3 years of 365-day periods
+    const period1End = mostRecentDate
+    const period1Start = new Date(mostRecentDate.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const period2End = new Date(mostRecentDate.getTime() - 365 * 24 * 60 * 60 * 1000)
+    const period2Start = new Date(mostRecentDate.getTime() - 730 * 24 * 60 * 60 * 1000)
+    const period3End = new Date(mostRecentDate.getTime() - 730 * 24 * 60 * 60 * 1000)
+    const period3Start = new Date(mostRecentDate.getTime() - 1095 * 24 * 60 * 60 * 1000)
+
+    const periods = [
+      { label: String(period1End.getFullYear()), startDate: period1Start, endDate: period1End, data: [] as any[] },
+      { label: String(period2End.getFullYear()), startDate: period2Start, endDate: period2End, data: [] as any[] },
+      { label: String(period3End.getFullYear()), startDate: period3Start, endDate: period3End, data: [] as any[] },
+    ]
+
+    // Group readings by period
+    readings.forEach((reading: any) => {
+      const dateStr = reading.date?.split('T')[0] || reading.date
+      if (!dateStr) return
+
+      const readingDate = new Date(dateStr)
+      const power = parseFloat(reading.value || 0) / 1000 // Convert W to kW
+
+      // Extract time from date field
+      let time = ''
+      if (reading.date?.includes('T')) {
+        time = reading.date.split('T')[1]?.substring(0, 5) || ''
+      } else if (reading.date?.includes(' ')) {
+        time = reading.date.split(' ')[1]?.substring(0, 5) || ''
+      }
+
+      periods.forEach(period => {
+        if (readingDate >= period.startDate && readingDate <= period.endDate) {
+          period.data.push({
+            date: dateStr,
+            power: power,
+            time: time,
+            year: period.label
+          })
+        }
+      })
+    })
+
+    // Sort data by date within each period
+    periods.forEach(period => {
+      period.data.sort((a, b) => a.date.localeCompare(b.date))
+    })
+
+    return periods.reverse()
+  }, [maxPowerData])
+
+  // Set default year when power data loads
+  useEffect(() => {
+    if (powerByYearData.length > 0) {
+      setSelectedPowerYear(powerByYearData.length - 1)
+    }
+  }, [powerByYearData.length])
+
+  // Process detailed consumption data by day (load curve)
+  const detailByDayData = useMemo(() => {
+    if (!detailData?.meter_reading?.interval_reading) {
+      return []
+    }
+
+    const readings = detailData.meter_reading.interval_reading
+    const unit = detailData.meter_reading.reading_type?.unit || 'W'
+    const intervalLength = detailData.meter_reading.reading_type?.interval_length || 'P30M'
+
+    const parseIntervalToDurationInHours = (interval: string): number => {
+      const match = interval.match(/^P(\d+)([DHM])$/)
+      if (!match) return 0.5
+
+      const value = parseInt(match[1], 10)
+      const unitType = match[2]
+
+      switch (unitType) {
+        case 'D': return value * 24
+        case 'H': return value
+        case 'M': return value / 60
+        default: return 0.5
+      }
+    }
+
+    const getIntervalMultiplier = (interval: string, valueUnit: string): number => {
+      if (valueUnit === 'Wh' || valueUnit === 'WH') return 1
+      if (valueUnit === 'W') {
+        return parseIntervalToDurationInHours(interval)
+      }
+      return 1
+    }
+
+    const intervalMultiplier = getIntervalMultiplier(intervalLength, unit)
+    const intervalDurationHours = parseIntervalToDurationInHours(intervalLength)
+
+    // Group readings by day
+    const dayMap: Record<string, any[]> = {}
+
+    readings.forEach((reading: any) => {
+      if (!reading.date) return
+
+      // Parse the API datetime
+      // NOTE: Backend already shifted timestamps to interval START (not END)
+      let measurementDateTime: Date
+
+      if (reading.date.includes('T')) {
+        measurementDateTime = new Date(reading.date)
+      } else if (reading.date.includes(' ')) {
+        measurementDateTime = new Date(reading.date.replace(' ', 'T'))
+      } else {
+        measurementDateTime = new Date(reading.date + 'T00:00:00')
+      }
+
+      // Extract date and time from the measurement start time
+      const year = measurementDateTime.getFullYear()
+      const month = String(measurementDateTime.getMonth() + 1).padStart(2, '0')
+      const day = String(measurementDateTime.getDate()).padStart(2, '0')
+      const hours = String(measurementDateTime.getHours()).padStart(2, '0')
+      const minutes = String(measurementDateTime.getMinutes()).padStart(2, '0')
+
+      const dateStr = `${year}-${month}-${day}`
+      const time = `${hours}:${minutes}`
+
+      if (!dayMap[dateStr]) {
+        dayMap[dateStr] = []
+      }
+
+      const rawValue = parseFloat(reading.value || 0)
+      const energyWh = rawValue * intervalMultiplier
+      const energyKwh = energyWh / 1000
+      const averagePowerW = intervalDurationHours > 0 ? energyWh / intervalDurationHours : rawValue
+      const averagePowerKw = averagePowerW / 1000
+
+      dayMap[dateStr].push({
+        time,
+        power: averagePowerKw,
+        energyWh,
+        energyKwh,
+        rawValue,
+        datetime: measurementDateTime.toISOString(),
+        apiDatetime: reading.date
+      })
+    })
+
+    // Convert to array and sort by date (no filter by detailDateRange - show all cached data for fluid navigation)
+    const days = Object.entries(dayMap)
+      .map(([date, data]) => ({
+        date,
+        data: data.sort((a, b) => a.time.localeCompare(b.time)),
+        totalEnergyKwh: data.reduce((sum, d) => sum + d.energyKwh, 0)
+      }))
+      .filter(day => day.data.length >= 10) // Filter days with very few data points (keep days with at least 10 points = 5h of data)
+      .sort((a, b) => b.date.localeCompare(a.date)) // Sort newest first
+
+    return days
+  }, [detailData])
+
+  // Calculate HC/HP statistics by year from all cached detailed data
+  const hcHpByYear = useMemo(() => {
+    if (!selectedPDL) {
+      return []
+    }
+
+    const offpeakRanges = parseOffpeakHours(selectedPDLDetails?.offpeak_hours)
+    const queryCache = queryClient.getQueryCache()
+    const allDetailQueries = queryCache.findAll({
+      queryKey: ['consumptionDetail', selectedPDL],
+      exact: false,
+    })
+
+    const allReadings: Array<{ date: Date; energyKwh: number; isHC: boolean }> = []
+
+    allDetailQueries.forEach((query) => {
+      const response = query.state.data as any
+      const data = response?.data
+
+      if (!data?.meter_reading?.interval_reading) return
+
+      const readings = data.meter_reading.interval_reading
+      const unit = data.meter_reading.reading_type?.unit || 'W'
+      const intervalLength = data.meter_reading.reading_type?.interval_length || 'P30M'
+
+
+      const parseIntervalToDurationInHours = (interval: string): number => {
+        const match = interval.match(/^P(\d+)([DHM])$/)
+        if (!match) return 0.5
+        const value = parseInt(match[1], 10)
+        const unitType = match[2]
+        switch (unitType) {
+          case 'D': return value * 24
+          case 'H': return value
+          case 'M': return value / 60
+          default: return 0.5
+        }
+      }
+
+      const intervalMultiplier = unit === 'W' ? parseIntervalToDurationInHours(intervalLength) : 1
+
+      readings.forEach((reading: any) => {
+        if (!reading.date || !reading.value) return
+
+        const dateTimeStr = reading.date.includes('T')
+          ? reading.date
+          : reading.date.replace(' ', 'T')
+        const apiDateTime = new Date(dateTimeStr)
+
+        const energyWh = parseFloat(reading.value) * intervalMultiplier
+        const energyKwh = energyWh / 1000
+
+        const hour = apiDateTime.getHours()
+        const minute = apiDateTime.getMinutes()
+        const isHC = isOffpeakTime(hour, minute, offpeakRanges)
+
+        allReadings.push({
+          date: apiDateTime,
+          energyKwh,
+          isHC
+        })
+      })
+    })
+
+    if (allReadings.length === 0) return []
+
+    // Remove duplicates by keeping only unique date/time combinations
+    const uniqueReadingsMap = new Map<string, { date: Date; energyKwh: number; isHC: boolean }>()
+    allReadings.forEach(reading => {
+      const key = reading.date.toISOString()
+      if (!uniqueReadingsMap.has(key)) {
+        uniqueReadingsMap.set(key, reading)
+      }
+    })
+
+    const uniqueReadings = Array.from(uniqueReadingsMap.values())
+
+    const mostRecentDate = new Date(Math.max(...uniqueReadings.map(r => r.date.getTime())))
+
+    // Define 3 rolling 365-day periods
+    const periods = []
+    for (let i = 0; i < 3; i++) {
+      const periodEnd = new Date(mostRecentDate)
+      periodEnd.setDate(mostRecentDate.getDate() - (i * 365))
+
+      const periodStart = new Date(periodEnd)
+      periodStart.setDate(periodEnd.getDate() - 364)
+
+      periods.push({
+        start: periodStart,
+        end: periodEnd,
+        label: `${periodStart.toLocaleDateString('fr-FR', { year: 'numeric', month: 'short', day: 'numeric' })} - ${periodEnd.toLocaleDateString('fr-FR', { year: 'numeric', month: 'short', day: 'numeric' })}`
+      })
+    }
+
+    const result = periods.map(period => {
+      const periodReadings = uniqueReadings.filter(r => r.date >= period.start && r.date <= period.end)
+
+      const hcKwh = periodReadings.filter(r => r.isHC).reduce((sum, r) => sum + r.energyKwh, 0)
+      const hpKwh = periodReadings.filter(r => !r.isHC).reduce((sum, r) => sum + r.energyKwh, 0)
+      const totalKwh = hcKwh + hpKwh
+
+      return {
+        year: period.label,
+        hcKwh,
+        hpKwh,
+        totalKwh
+      }
+    }).filter(p => p.totalKwh > 0)
+
+    return result
+  }, [selectedPDL, selectedPDLDetails?.offpeak_hours, hcHpCalculationTrigger, queryClient])
+
+  // Calculate monthly HC/HP data for each rolling year period
+  const monthlyHcHpByYear = useMemo(() => {
+    if (!selectedPDL || !selectedPDLDetails?.offpeak_hours) {
+      return []
+    }
+
+    const offpeakRanges = parseOffpeakHours(selectedPDLDetails.offpeak_hours)
+    const queryCache = queryClient.getQueryCache()
+    const allDetailQueries = queryCache.findAll({
+      queryKey: ['consumptionDetail', selectedPDL],
+      exact: false,
+    })
+
+    if (allDetailQueries.length === 0) return []
+
+
+    const allReadings: Array<{ date: Date; energyKwh: number; isHC: boolean }> = []
+
+    allDetailQueries.forEach((query) => {
+      const response = query.state.data as any
+      const data = response?.data
+
+      if (!data?.meter_reading?.interval_reading) return
+
+      const readings = data.meter_reading.interval_reading
+      const unit = data.meter_reading.reading_type?.unit || 'W'
+      const intervalLength = data.meter_reading.reading_type?.interval_length || 'P30M'
+
+
+      const parseIntervalToDurationInHours = (interval: string): number => {
+        const match = interval.match(/^P(\d+)([DHM])$/)
+        if (!match) return 0.5
+        const value = parseInt(match[1], 10)
+        const unitType = match[2]
+        switch (unitType) {
+          case 'D': return value * 24
+          case 'H': return value
+          case 'M': return value / 60
+          default: return 0.5
+        }
+      }
+
+      const intervalMultiplier = unit === 'W' ? parseIntervalToDurationInHours(intervalLength) : 1
+
+      readings.forEach((reading: any) => {
+        if (!reading.date || !reading.value) return
+
+        const dateTimeStr = reading.date.includes('T') ? reading.date : reading.date.replace(' ', 'T')
+        const apiDateTime = new Date(dateTimeStr)
+        const energyWh = parseFloat(reading.value) * intervalMultiplier
+        const energyKwh = energyWh / 1000
+        const hour = apiDateTime.getHours()
+        const minute = apiDateTime.getMinutes()
+        const isHC = isOffpeakTime(hour, minute, offpeakRanges)
+
+        allReadings.push({ date: apiDateTime, energyKwh, isHC })
+      })
+    })
+
+    if (allReadings.length === 0) return []
+
+    // Remove duplicates by keeping only unique date/time combinations
+    const uniqueReadingsMap = new Map<string, { date: Date; energyKwh: number; isHC: boolean }>()
+    allReadings.forEach(reading => {
+      const key = reading.date.toISOString()
+      if (!uniqueReadingsMap.has(key)) {
+        uniqueReadingsMap.set(key, reading)
+      }
+    })
+
+    const uniqueReadings = Array.from(uniqueReadingsMap.values())
+
+    const mostRecentDate = new Date(Math.max(...uniqueReadings.map(r => r.date.getTime())))
+
+    // Define 2 rolling 365-day periods (max 730 days from API)
+    // Period 1: Most recent 365 days (from yesterday back 365 days)
+    // Period 2: Previous 365 days (from 365 days ago back to 730 days ago)
+    const periods = []
+
+    // Period 1: Last 365 days (e.g., Nov 11, 2024 to Nov 10, 2025)
+    const period1End = new Date(mostRecentDate)
+    const period1Start = new Date(mostRecentDate)
+    period1Start.setDate(period1Start.getDate() - 364) // 365 days total including end date
+
+    periods.push({
+      start: period1Start,
+      end: period1End,
+      label: period1End.getFullYear().toString() // 2025
+    })
+
+    // Period 2: Previous 365 days (e.g., Nov 11, 2023 to Nov 10, 2024)
+    const period2End = new Date(period1Start)
+    period2End.setDate(period2End.getDate() - 1) // Day before period 1 starts
+    const period2Start = new Date(period2End)
+    period2Start.setDate(period2Start.getDate() - 364) // 365 days total
+
+    periods.push({
+      start: period2Start,
+      end: period2End,
+      label: period2End.getFullYear().toString() // 2024
+    })
+
+    const result = periods.map(period => {
+      const periodReadings = uniqueReadings.filter(r => r.date >= period.start && r.date <= period.end)
+
+      // Count available data days for this period
+      const uniqueDays = new Set(periodReadings.map(r => r.date.toDateString())).size
+
+      const monthlyData: Record<string, { hcKwh: number; hpKwh: number; month: string }> = {}
+
+      periodReadings.forEach(reading => {
+        const monthKey = `${reading.date.getFullYear()}-${String(reading.date.getMonth() + 1).padStart(2, '0')}`
+
+        if (!monthlyData[monthKey]) {
+          monthlyData[monthKey] = {
+            hcKwh: 0,
+            hpKwh: 0,
+            month: new Date(reading.date.getFullYear(), reading.date.getMonth(), 1)
+              .toLocaleDateString('fr-FR', { month: 'short', year: 'numeric' })
+          }
+        }
+
+        if (reading.isHC) {
+          monthlyData[monthKey].hcKwh += reading.energyKwh
+        } else {
+          monthlyData[monthKey].hpKwh += reading.energyKwh
+        }
+      })
+
+      const months = Object.keys(monthlyData).sort().map(key => ({
+        month: monthlyData[key].month,
+        hcKwh: monthlyData[key].hcKwh,
+        hpKwh: monthlyData[key].hpKwh,
+        totalKwh: monthlyData[key].hcKwh + monthlyData[key].hpKwh
+      }))
+
+      return {
+        year: period.label,
+        months,
+        dataAvailable: uniqueDays, // Number of days with data
+        totalDays: 365
+      }
+    }).filter(p => p.months.length >= 12)
+
+    return result
+  }, [selectedPDL, selectedPDLDetails?.offpeak_hours, hcHpCalculationTrigger, queryClient])
+
+  return {
+    chartData,
+    powerByYearData,
+    selectedPowerYear,
+    setSelectedPowerYear,
+    detailByDayData,
+    hcHpByYear,
+    monthlyHcHpByYear
+  }
+}

--- a/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionData.ts
+++ b/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionData.ts
@@ -1,0 +1,297 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState, useEffect } from 'react'
+import { pdlApi } from '@/api/pdl'
+import { enedisApi, type EnedisData } from '@/api/enedis'
+import type { PDL, APIResponse } from '@/types/api'
+import type { DateRange } from '../types/consumption.types'
+
+// Full response type for Enedis API
+type EnedisApiResponse = APIResponse<EnedisData>
+
+export function useConsumptionData(selectedPDL: string, dateRange: DateRange | null, _detailDateRange: DateRange | null) {
+  const queryClient = useQueryClient()
+
+  // Fetch PDLs
+  const { data: pdlsData } = useQuery({
+    queryKey: ['pdls'],
+    queryFn: async () => {
+      const response = await pdlApi.list()
+      if (response.success && Array.isArray(response.data)) {
+        return response.data as PDL[]
+      }
+      return []
+    },
+  })
+
+  const pdls = Array.isArray(pdlsData) ? pdlsData : []
+
+  // Filter only active PDLs (if is_active is undefined, consider it as active)
+  const activePdls = pdls.filter(p => p.is_active !== false)
+
+  // Get selected PDL details
+  const selectedPDLDetails = pdls.find(p => p.usage_point_id === selectedPDL)
+
+  // Fetch consumption data with React Query
+  // Use a single cache key per PDL (no date in key to avoid cache fragmentation)
+  const { data: consumptionResponse, isLoading: isLoadingConsumption } = useQuery<EnedisApiResponse | null>({
+    queryKey: ['consumptionDaily', selectedPDL],
+    enabled: !!selectedPDL && !!dateRange,
+    queryFn: async (): Promise<EnedisApiResponse | null> => {
+      if (!selectedPDL || !dateRange) return null
+
+      // Calculate the total date range in days
+      const startDate = new Date(dateRange.start + 'T00:00:00Z')
+      const endDate = new Date(dateRange.end + 'T00:00:00Z')
+      const totalDays = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+
+      // If the range is <= 365 days, make a single call
+      if (totalDays <= 365) {
+        return enedisApi.getConsumptionDaily(selectedPDL, {
+          start: dateRange.start,
+          end: dateRange.end,
+          use_cache: true,
+        })
+      }
+
+      // Split into yearly chunks (max 365 days per call)
+      const yearlyChunks: { start: string; end: string }[] = []
+      let currentStart = new Date(startDate)
+
+      while (currentStart <= endDate) {
+        // Calculate end of this chunk (1 year or less)
+        let currentEnd = new Date(currentStart)
+        currentEnd.setUTCFullYear(currentEnd.getUTCFullYear() + 1)
+        currentEnd.setUTCDate(currentEnd.getUTCDate() - 1) // 365 days max
+
+        // Cap to overall end date if needed
+        if (currentEnd > endDate) {
+          currentEnd = new Date(endDate)
+        }
+
+        const chunkStart = currentStart.getUTCFullYear() + '-' +
+                          String(currentStart.getUTCMonth() + 1).padStart(2, '0') + '-' +
+                          String(currentStart.getUTCDate()).padStart(2, '0')
+        const chunkEnd = currentEnd.getUTCFullYear() + '-' +
+                        String(currentEnd.getUTCMonth() + 1).padStart(2, '0') + '-' +
+                        String(currentEnd.getUTCDate()).padStart(2, '0')
+
+        yearlyChunks.push({ start: chunkStart, end: chunkEnd })
+
+        // Move to next chunk (day after current end)
+        currentStart = new Date(currentEnd)
+        currentStart.setUTCDate(currentStart.getUTCDate() + 1)
+      }
+
+      // Fetch all chunks in parallel
+      const chunkPromises = yearlyChunks.map(chunk =>
+        enedisApi.getConsumptionDaily(selectedPDL, {
+          start: chunk.start,
+          end: chunk.end,
+          use_cache: true,
+        })
+      )
+
+      const chunkResults = await Promise.all(chunkPromises) as EnedisApiResponse[]
+
+      // Merge all chunks into a single response
+      // Take the first successful response as the base
+      const firstSuccess = chunkResults.find(r => r?.success)
+      if (!firstSuccess) {
+        // If no successful response, return the first one (which will be an error)
+        return chunkResults[0]
+      }
+
+      // Combine all interval_reading arrays
+      const allReadings: Array<{ date: string; value: string | number }> = []
+      for (const result of chunkResults) {
+        if (result?.success && result?.data?.meter_reading?.interval_reading) {
+          allReadings.push(...result.data.meter_reading.interval_reading)
+        }
+      }
+
+      // Return merged response
+      return {
+        ...firstSuccess,
+        data: {
+          ...firstSuccess.data,
+          meter_reading: {
+            ...firstSuccess.data?.meter_reading,
+            interval_reading: allReadings
+          }
+        }
+      }
+    },
+    staleTime: 1000 * 60 * 60, // 1 hour - data is considered fresh
+    gcTime: 1000 * 60 * 60 * 24, // 24 hours - keep in cache
+    refetchOnMount: true, // Always refetch on component mount if data is stale
+  })
+
+  // Fetch max power data with React Query
+  // Use a single cache key per PDL (no date in key to avoid cache fragmentation)
+  const { data: maxPowerResponse, isLoading: isLoadingPower } = useQuery<EnedisApiResponse | null>({
+    queryKey: ['maxPower', selectedPDL],
+    enabled: !!selectedPDL && !!dateRange,
+    queryFn: async (): Promise<EnedisApiResponse | null> => {
+      if (!selectedPDL || !dateRange) return null
+
+      // Calculate the total date range in days
+      const startDate = new Date(dateRange.start + 'T00:00:00Z')
+      const endDate = new Date(dateRange.end + 'T00:00:00Z')
+      const totalDays = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+
+      // If the range is <= 365 days, make a single call
+      if (totalDays <= 365) {
+        return enedisApi.getMaxPower(selectedPDL, {
+          start: dateRange.start,
+          end: dateRange.end,
+          use_cache: true,
+        })
+      }
+
+      // Split into yearly chunks (max 365 days per call)
+      const yearlyChunks: { start: string; end: string }[] = []
+      let currentStart = new Date(startDate)
+
+      while (currentStart <= endDate) {
+        // Calculate end of this chunk (1 year or less)
+        let currentEnd = new Date(currentStart)
+        currentEnd.setUTCFullYear(currentEnd.getUTCFullYear() + 1)
+        currentEnd.setUTCDate(currentEnd.getUTCDate() - 1) // 365 days max
+
+        // Cap to overall end date if needed
+        if (currentEnd > endDate) {
+          currentEnd = new Date(endDate)
+        }
+
+        const chunkStart = currentStart.getUTCFullYear() + '-' +
+                          String(currentStart.getUTCMonth() + 1).padStart(2, '0') + '-' +
+                          String(currentStart.getUTCDate()).padStart(2, '0')
+        const chunkEnd = currentEnd.getUTCFullYear() + '-' +
+                        String(currentEnd.getUTCMonth() + 1).padStart(2, '0') + '-' +
+                        String(currentEnd.getUTCDate()).padStart(2, '0')
+
+        yearlyChunks.push({ start: chunkStart, end: chunkEnd })
+
+        // Move to next chunk (day after current end)
+        currentStart = new Date(currentEnd)
+        currentStart.setUTCDate(currentStart.getUTCDate() + 1)
+      }
+
+      // Fetch all chunks in parallel
+      const chunkPromises = yearlyChunks.map(chunk =>
+        enedisApi.getMaxPower(selectedPDL, {
+          start: chunk.start,
+          end: chunk.end,
+          use_cache: true,
+        })
+      )
+
+      const chunkResults = await Promise.all(chunkPromises) as EnedisApiResponse[]
+
+      // Merge all chunks into a single response
+      // Take the first successful response as the base
+      const firstSuccess = chunkResults.find(r => r?.success)
+      if (!firstSuccess) {
+        // If no successful response, return the first one (which will be an error)
+        return chunkResults[0]
+      }
+
+      // Combine all interval_reading arrays
+      const allReadings: Array<{ date: string; value: string | number }> = []
+      for (const result of chunkResults) {
+        if (result?.success && result?.data?.meter_reading?.interval_reading) {
+          allReadings.push(...result.data.meter_reading.interval_reading)
+        }
+      }
+
+      // Return merged response
+      return {
+        ...firstSuccess,
+        data: {
+          ...firstSuccess.data,
+          meter_reading: {
+            ...firstSuccess.data?.meter_reading,
+            interval_reading: allReadings
+          }
+        }
+      }
+    },
+    staleTime: 1000 * 60 * 60, // 1 hour
+    gcTime: 1000 * 60 * 60 * 24, // 24 hours
+    refetchOnMount: true, // Always refetch on component mount if data is stale
+  })
+
+  // Fetch detailed consumption data (load curve - 30min intervals)
+  // HYBRID APPROACH: useQuery creates the cache entry for persistence,
+  // but we read data via subscription to avoid race conditions
+
+  // 1. Create query entry (needed for React Query Persist)
+  // CRITICAL: queryFn reads from cache, making the query "succeed" with persisted data
+  useQuery({
+    queryKey: ['consumptionDetail', selectedPDL],
+    queryFn: async () => {
+      // Read from cache - this makes the query succeed with status: 'success'
+      // Data is written to cache via setQueryData in useUnifiedDataFetch
+      const cachedData = queryClient.getQueryData(['consumptionDetail', selectedPDL])
+      return cachedData || null
+    },
+    enabled: !!selectedPDL, // Run once when PDL is set (reads persisted data)
+    staleTime: Infinity, // Never refetch - data only comes from setQueryData
+    gcTime: 1000 * 60 * 60 * 24 * 7, // 7 days
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+
+  // 2. Read data via direct cache access + subscription (avoids race conditions)
+  const [detailResponse, setDetailResponse] = useState<any>(null)
+  const [isLoadingDetail] = useState(false)
+
+  useEffect(() => {
+    if (!selectedPDL) {
+      setDetailResponse(null)
+      return
+    }
+
+    // Read current data from cache (includes persisted data)
+    const initialData = queryClient.getQueryData(['consumptionDetail', selectedPDL])
+    if (initialData) {
+      setDetailResponse(initialData)
+    }
+
+    // Subscribe to future changes (when setQueryData is called)
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (
+        event?.type === 'updated' &&
+        event?.query?.queryKey?.[0] === 'consumptionDetail' &&
+        event?.query?.queryKey?.[1] === selectedPDL
+      ) {
+        const updatedData = queryClient.getQueryData(['consumptionDetail', selectedPDL])
+        setDetailResponse(updatedData)
+      }
+    })
+
+    return () => unsubscribe()
+  }, [selectedPDL, queryClient])
+
+  const consumptionData = consumptionResponse?.success ? consumptionResponse.data ?? null : null
+  const maxPowerData = maxPowerResponse?.success ? maxPowerResponse.data ?? null : null
+  const detailData = (detailResponse as EnedisApiResponse | null)?.success
+    ? (detailResponse as EnedisApiResponse).data ?? null
+    : null
+  const isLoading = isLoadingConsumption || isLoadingPower || isLoadingDetail
+
+  return {
+    pdls,
+    activePdls,
+    selectedPDLDetails,
+    consumptionData,
+    maxPowerData,
+    detailData,
+    isLoading,
+    isLoadingConsumption,
+    isLoadingPower,
+    isLoadingDetail,
+    queryClient
+  }
+}

--- a/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionFetch.ts
+++ b/apps/web/src/pages/ConsumptionKwh/hooks/useConsumptionFetch.ts
@@ -1,0 +1,434 @@
+import { useCallback } from 'react'
+import { useQueryClient, useQuery } from '@tanstack/react-query'
+import { enedisApi } from '@/api/enedis'
+import { adminApi } from '@/api/admin'
+import { pdlApi } from '@/api/pdl'
+import { logger } from '@/utils/logger'
+import toast from 'react-hot-toast'
+import type { PDL } from '@/types/api'
+import type { DateRange, LoadingProgress } from '../types/consumption.types'
+
+interface UseConsumptionFetchParams {
+  selectedPDL: string
+  selectedPDLDetails: PDL | undefined
+  setDateRange: (value: DateRange | null) => void
+  setIsChartsExpanded: (value: boolean) => void
+  setIsDetailSectionExpanded: (value: boolean) => void
+  setIsStatsSectionExpanded: (value: boolean) => void
+  setIsPowerSectionExpanded: (value: boolean) => void
+  setHcHpCalculationComplete: (value: boolean) => void
+  setDailyLoadingComplete: (value: boolean) => void
+  setPowerLoadingComplete: (value: boolean) => void
+  setAllLoadingComplete: (value: boolean) => void
+  setIsLoadingDetailed: (value: boolean) => void
+  setLoadingProgress: (value: LoadingProgress) => void
+  setHcHpCalculationTrigger: (updater: (prev: number) => number) => void
+  setIsClearingCache: (value: boolean) => void
+}
+
+export function useConsumptionFetch({
+  selectedPDL,
+  selectedPDLDetails,
+  setDateRange,
+  setIsChartsExpanded,
+  setIsDetailSectionExpanded,
+  setIsStatsSectionExpanded,
+  setIsPowerSectionExpanded,
+  setHcHpCalculationComplete,
+  setDailyLoadingComplete,
+  setPowerLoadingComplete,
+  setAllLoadingComplete,
+  setIsLoadingDetailed,
+  setLoadingProgress,
+  setHcHpCalculationTrigger,
+  setIsClearingCache,
+}: UseConsumptionFetchParams) {
+  const queryClient = useQueryClient()
+
+  // Get the list of PDLs to find production PDL details
+  const { data: pdlsResponse } = useQuery({
+    queryKey: ['pdls'],
+    queryFn: pdlApi.list,
+  })
+  const allPDLs: PDL[] = Array.isArray(pdlsResponse) ? pdlsResponse : []
+
+  const fetchConsumptionData = useCallback(async () => {
+    if (!selectedPDL) {
+      toast.error('Veuillez sélectionner un PDL')
+      return
+    }
+
+    // Invalidate existing queries to force refetch
+    queryClient.invalidateQueries({ queryKey: ['consumption', selectedPDL] })
+    queryClient.invalidateQueries({ queryKey: ['maxPower', selectedPDL] })
+
+    // Collapse all sections before fetching new data
+    setIsChartsExpanded(false)
+    setIsDetailSectionExpanded(false)
+    setIsStatsSectionExpanded(false)
+    setIsPowerSectionExpanded(false)
+    setHcHpCalculationComplete(false)
+    setDailyLoadingComplete(false)
+    setPowerLoadingComplete(false)
+    setAllLoadingComplete(false)
+
+    // Calculate dates for consumption and power (3 years max - 1095 days)
+    // Use yesterday as end date because Enedis data is only available in J-1
+    // IMPORTANT: Use LOCAL time to determine "today" and "yesterday" (user's perspective)
+    // The API expects YYYY-MM-DD format, so timezone doesn't matter for the date itself
+    const now = new Date()
+
+    // Get yesterday in LOCAL time (end date)
+    // This ensures that at 0h30 local time, "yesterday" is still the previous calendar day
+    const yesterday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - 1,
+      12, 0, 0, 0  // Use noon to avoid any DST edge cases
+    )
+
+    // Start date: 1095 days before yesterday (Enedis API max limit for daily data - 3 years)
+    let startDate_obj = new Date(
+      yesterday.getFullYear(),
+      yesterday.getMonth(),
+      yesterday.getDate() - 1095,
+      12, 0, 0, 0
+    )
+
+    // Apply limits: never go before oldest_available_data_date or activation_date
+    logger.log('PDL Details:', {
+      selectedPDL,
+      oldest_available_data_date: selectedPDLDetails?.oldest_available_data_date,
+      activation_date: selectedPDLDetails?.activation_date,
+      calculatedStartDate: startDate_obj.toISOString().split('T')[0]
+    })
+
+    // For now, don't apply oldest_available_data_date or activation_date limits
+    // Let the API handle the error and we'll display it to the user
+    // TODO: Implement proper retry logic with progressive date advancement
+    logger.log(`Daily consumption: Requesting full 3 years (API will return error if too old)`)
+
+    // Format dates as YYYY-MM-DD using LOCAL time (user's perspective)
+    const startDate = startDate_obj.getFullYear() + '-' +
+                      String(startDate_obj.getMonth() + 1).padStart(2, '0') + '-' +
+                      String(startDate_obj.getDate()).padStart(2, '0')
+    const endDate = yesterday.getFullYear() + '-' +
+                    String(yesterday.getMonth() + 1).padStart(2, '0') + '-' +
+                    String(yesterday.getDate()).padStart(2, '0')
+
+    logger.log(`Final date range for API: ${startDate} → ${endDate}`)
+
+    // Setting dateRange will trigger React Query to fetch data
+    setDateRange({ start: startDate, end: endDate })
+
+    // Pre-fetch detailed data for 2 years (730 days) using the new batch endpoint
+    // The backend handles all the chunking and caching logic
+    if (selectedPDLDetails?.is_active && selectedPDLDetails?.has_consumption) {
+      setIsLoadingDetailed(true)
+
+      // Calculate 2 years back from TODAY (not yesterday) - 729 days
+      // Start: today - 2 years, End: yesterday (J-1)
+      // Use LOCAL time for user's perspective
+      const todayLocal = new Date()
+      const today = new Date(
+        todayLocal.getFullYear(),
+        todayLocal.getMonth(),
+        todayLocal.getDate(),
+        12, 0, 0, 0  // Use noon to avoid DST edge cases
+      )
+
+      const twoYearsAgo = new Date(
+        today.getFullYear() - 2,
+        today.getMonth(),
+        today.getDate(),
+        12, 0, 0, 0
+      )
+
+      const startDate = twoYearsAgo.getFullYear() + '-' +
+                       String(twoYearsAgo.getMonth() + 1).padStart(2, '0') + '-' +
+                       String(twoYearsAgo.getDate()).padStart(2, '0')
+
+      const endDate = yesterday.getFullYear() + '-' +
+                     String(yesterday.getMonth() + 1).padStart(2, '0') + '-' +
+                     String(yesterday.getDate()).padStart(2, '0')
+
+      logger.log(`Detailed data: Requesting 2 years via batch endpoint (${startDate} to ${endDate}) - 729 days`)
+
+      try {
+        // Single batch call to get all detailed data for 2 years
+        setLoadingProgress({ current: 0, total: 1, currentRange: `${startDate} → ${endDate}` })
+
+        const batchData = await enedisApi.getConsumptionDetailBatch(selectedPDL, {
+          start: startDate,
+          end: endDate,
+          use_cache: true,
+        })
+
+        logger.log(`Batch response:`, {
+          success: batchData?.success,
+          hasError: !!batchData?.error,
+          errorCode: batchData?.error?.code,
+          dataPoints: (batchData as any)?.data?.meter_reading?.interval_reading?.length || 0
+        })
+
+        if (batchData?.success && (batchData as any)?.data?.meter_reading?.interval_reading) {
+          const readings = (batchData as any).data.meter_reading.interval_reading
+
+          // Deduplicate readings using a Map with timestamp as key
+          const uniqueReadingsMap = new Map()
+          readings.forEach((point: any) => {
+            uniqueReadingsMap.set(point.date, point)
+          })
+          const uniqueReadings = Array.from(uniqueReadingsMap.values())
+
+          // Store ALL detail data in a SINGLE cache key (not per day!)
+          // This avoids creating 730+ cache entries that overload IndexedDB
+          queryClient.setQueryData(['consumptionDetail', selectedPDL], {
+            success: true,
+            data: {
+              meter_reading: {
+                interval_reading: uniqueReadings
+              }
+            }
+          })
+
+          // Calculate day count for display
+          const dates = new Set(uniqueReadings.map((p: any) => p.date.split(' ')[0].split('T')[0]))
+          const dayCount = dates.size
+          const years = Math.floor(dayCount / 365)
+          const remainingDays = dayCount % 365
+          const yearsText = years > 0 ? `${years} an${years > 1 ? 's' : ''}` : ''
+          const daysText = remainingDays > 0 ? `${remainingDays} jour${remainingDays > 1 ? 's' : ''}` : ''
+          const periodText = [yearsText, daysText].filter(Boolean).join(' et ')
+
+          toast.success(`Historique chargé avec succès (${periodText} de données, ${readings.length} points)`, {
+            duration: 4000,
+          })
+
+          // Show cache persistence indicator
+          const persistToast = toast.loading('💾 Mise en cache des données...', { duration: 2000 })
+          setTimeout(() => {
+            toast.dismiss(persistToast)
+            setLoadingProgress({ current: 1, total: 1, currentRange: 'Terminé !' })
+
+            // Expand all sections to show the data
+            setIsChartsExpanded(true)
+            setIsDetailSectionExpanded(true)
+            setIsStatsSectionExpanded(true)
+            setIsPowerSectionExpanded(true)
+            setDailyLoadingComplete(true)
+            setPowerLoadingComplete(true)
+            setAllLoadingComplete(true)
+          }, 1500)
+        } else if (batchData?.error) {
+          // Handle partial data or errors
+          const errorMsg = batchData.error.message || 'Erreur lors du chargement des données détaillées'
+
+          if (batchData.error.code === 'PARTIAL_DATA') {
+            toast.success(errorMsg, { duration: 4000, icon: '⚠️' })
+          } else {
+            toast.error(errorMsg, { duration: 6000 })
+          }
+        }
+
+        // Invalidate the detail query to force it to re-fetch from cache
+        queryClient.invalidateQueries({ queryKey: ['consumptionDetail'] })
+
+        // Trigger HC/HP calculation now that all data is loaded
+        setHcHpCalculationTrigger(prev => prev + 1)
+      } catch (error: any) {
+        console.error('Error fetching detailed data via batch:', error)
+
+        const errorMsg = error?.response?.data?.error?.message ||
+                        error?.message ||
+                        'Erreur lors du chargement des données détaillées'
+        toast.error(errorMsg)
+      } finally {
+        setIsLoadingDetailed(false)
+        // Don't reset loadingProgress here - keep the final state (1/1 for success)
+      }
+    }
+
+    // If this consumption PDL is linked to a production PDL, fetch production data too
+    if (selectedPDLDetails?.linked_production_pdl_id) {
+      const productionPDL = allPDLs.find(p => p.id === selectedPDLDetails.linked_production_pdl_id)
+
+      if (!productionPDL) {
+        logger.log(`Production PDL not found in list: ${selectedPDLDetails.linked_production_pdl_id}`)
+        return
+      }
+
+      const productionPdlUsagePointId = productionPDL.usage_point_id
+      logger.log(`Linked production PDL detected: ${productionPdlUsagePointId}, fetching production data...`)
+
+      try {
+        // Invalidate production queries to force refetch
+        queryClient.invalidateQueries({ queryKey: ['production', productionPdlUsagePointId] })
+
+        // Fetch production daily data (3 years)
+        // Use LOCAL time for user's perspective
+        const nowLocal = new Date()
+        const yesterdayLocal = new Date(
+          nowLocal.getFullYear(),
+          nowLocal.getMonth(),
+          nowLocal.getDate() - 1,
+          12, 0, 0, 0  // Use noon to avoid DST edge cases
+        )
+
+        const threeYearsAgo = new Date(
+          yesterdayLocal.getFullYear(),
+          yesterdayLocal.getMonth(),
+          yesterdayLocal.getDate() - 1095,
+          12, 0, 0, 0
+        )
+
+        const startDate3y = threeYearsAgo.getFullYear() + '-' +
+                           String(threeYearsAgo.getMonth() + 1).padStart(2, '0') + '-' +
+                           String(threeYearsAgo.getDate()).padStart(2, '0')
+        const endDate = yesterdayLocal.getFullYear() + '-' +
+                       String(yesterdayLocal.getMonth() + 1).padStart(2, '0') + '-' +
+                       String(yesterdayLocal.getDate()).padStart(2, '0')
+
+        logger.log(`Fetching production daily data: ${startDate3y} → ${endDate}`)
+
+        // Note: We don't await these - they will be fetched and cached in background
+        // The production page will use the cached data when the user navigates to it
+        enedisApi.getProductionDaily(productionPdlUsagePointId, {
+          start: startDate3y,
+          end: endDate,
+          use_cache: true,
+        }).then(dailyData => {
+          if (dailyData?.success) {
+            queryClient.setQueryData(
+              ['production', productionPdlUsagePointId, startDate3y, endDate],
+              dailyData
+            )
+            logger.log('Production daily data cached successfully')
+          }
+        }).catch(err => {
+          logger.log('Error fetching production daily data:', err)
+        })
+
+        // Fetch production detailed data (2 years) via batch endpoint
+        // Use LOCAL time for user's perspective
+        const todayLocal = new Date(
+          nowLocal.getFullYear(),
+          nowLocal.getMonth(),
+          nowLocal.getDate(),
+          12, 0, 0, 0
+        )
+
+        const twoYearsAgo = new Date(
+          todayLocal.getFullYear() - 2,
+          todayLocal.getMonth(),
+          todayLocal.getDate(),
+          12, 0, 0, 0
+        )
+
+        const startDate2y = twoYearsAgo.getFullYear() + '-' +
+                           String(twoYearsAgo.getMonth() + 1).padStart(2, '0') + '-' +
+                           String(twoYearsAgo.getDate()).padStart(2, '0')
+
+        logger.log(`Fetching production detail batch: ${startDate2y} → ${endDate}`)
+
+        enedisApi.getProductionDetailBatch(productionPdlUsagePointId, {
+          start: startDate2y,
+          end: endDate,
+          use_cache: true,
+        }).then(batchData => {
+          if (batchData?.success && (batchData as any)?.data?.meter_reading?.interval_reading) {
+            const readings = (batchData as any).data.meter_reading.interval_reading
+
+            // Deduplicate readings using a Map with timestamp as key
+            const uniqueReadingsMap = new Map()
+            readings.forEach((point: any) => {
+              uniqueReadingsMap.set(point.date, point)
+            })
+            const uniqueReadings = Array.from(uniqueReadingsMap.values())
+
+            // Store ALL detail data in a SINGLE cache key (not per day!)
+            // This avoids creating 730+ cache entries that overload IndexedDB
+            queryClient.setQueryData(['productionDetail', productionPdlUsagePointId], {
+              success: true,
+              data: {
+                meter_reading: {
+                  interval_reading: uniqueReadings
+                }
+              }
+            })
+
+            const dates = new Set(uniqueReadings.map((p: any) => p.date.split(' ')[0].split('T')[0]))
+            logger.log(`Production detail data cached successfully: ${dates.size} days, ${uniqueReadings.length} points`)
+
+            // Invalidate the detail query to make it available
+            queryClient.invalidateQueries({ queryKey: ['productionDetail'] })
+          }
+        }).catch(err => {
+          logger.log('Error fetching production detail batch:', err)
+        })
+
+        logger.log('Production data fetch initiated in background')
+      } catch (error: any) {
+        logger.log('Error initiating production data fetch:', error)
+        // Don't show error to user - this is a background operation
+      }
+    }
+  }, [
+    selectedPDL,
+    selectedPDLDetails,
+    allPDLs,
+    setDateRange,
+    setIsChartsExpanded,
+    setIsDetailSectionExpanded,
+    setIsStatsSectionExpanded,
+    setIsPowerSectionExpanded,
+    setHcHpCalculationComplete,
+    setDailyLoadingComplete,
+    setPowerLoadingComplete,
+    setAllLoadingComplete,
+    setIsLoadingDetailed,
+    setLoadingProgress,
+    setHcHpCalculationTrigger,
+    queryClient
+  ])
+
+  const clearCache = useCallback(async () => {
+    setIsClearingCache(true)
+    try {
+      // Clear server-side cache for all consumption data FIRST
+      await adminApi.clearAllConsumptionCache()
+
+      // Clear React Query cache
+      queryClient.clear()
+
+      // Clear React Query persister to prevent cache restoration on reload
+      localStorage.removeItem('myelectricaldata-query-cache')
+
+      // Clear IndexedDB if it exists
+      if ('indexedDB' in window) {
+        const databases = await indexedDB.databases()
+        for (const db of databases) {
+          if (db.name) {
+            await indexedDB.deleteDatabase(db.name)
+          }
+        }
+      }
+
+      toast.success('Cache vidé avec succès')
+
+      // Reload the page to start fresh
+      setTimeout(() => {
+        window.location.reload()
+      }, 1000)
+    } catch (error: any) {
+      toast.error(`Erreur lors de la suppression du cache: ${error.message}`)
+    } finally {
+      setIsClearingCache(false)
+    }
+  }, [setIsClearingCache, queryClient])
+
+  return {
+    fetchConsumptionData,
+    clearCache
+  }
+}

--- a/apps/web/src/pages/ConsumptionKwh/index.tsx
+++ b/apps/web/src/pages/ConsumptionKwh/index.tsx
@@ -1,0 +1,759 @@
+import { useState, useEffect, useMemo } from 'react'
+import { TrendingUp, BarChart3, Database, ArrowRight } from 'lucide-react'
+import { usePdlStore } from '@/stores/pdlStore'
+import { logger } from '@/utils/logger'
+import { LoadingOverlay } from '@/components/LoadingOverlay'
+import { LoadingPlaceholder } from '@/components/LoadingPlaceholder'
+import { AnimatedSection } from '@/components/AnimatedSection'
+
+// Import custom hooks
+import { useConsumptionData } from './hooks/useConsumptionData'
+import { useConsumptionFetch } from './hooks/useConsumptionFetch'
+import { useConsumptionCalcs } from './hooks/useConsumptionCalcs'
+
+// Import components
+import { InfoBlock } from './components/InfoBlock'
+import { ConfirmModal } from './components/ConfirmModal'
+import { YearlyConsumption } from './components/YearlyConsumption'
+import { HcHpDistribution } from './components/HcHpDistribution'
+import { YearlyStatCards } from './components/YearlyStatCards'
+import { AnnualCurve } from './components/AnnualCurve'
+import { DetailedCurve } from '@/components/DetailedCurve'
+import { MonthlyHcHp } from './components/MonthlyHcHp'
+import { PowerPeaks } from './components/PowerPeaks'
+
+// Renamed from Consumption to ConsumptionKwh
+export default function ConsumptionKwh() {
+  const { selectedPdl: selectedPDL, setSelectedPdl: setSelectedPDL } = usePdlStore()
+
+  // States
+  const [, setIsClearingCache] = useState(false)
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
+  const [isChartsExpanded, setIsChartsExpanded] = useState(false)
+  const [dateRange, setDateRange] = useState<{start: string, end: string} | null>(null)
+  const [isPowerSectionExpanded, setIsPowerSectionExpanded] = useState(true)
+  const [isStatsSectionExpanded, setIsStatsSectionExpanded] = useState(true)
+  const [isDetailSectionExpanded, setIsDetailSectionExpanded] = useState(true)
+  const [detailWeekOffset, setDetailWeekOffset] = useState<number>(0)
+  const [loadingProgress, setLoadingProgress] = useState({ current: 0, total: 0, currentRange: '' })
+  const [isLoadingDetailed, setIsLoadingDetailed] = useState(false)
+  const [, setIsLoadingDaily] = useState(false)
+  const [dailyLoadingComplete, setDailyLoadingComplete] = useState(false)
+  const [powerLoadingComplete, setPowerLoadingComplete] = useState(false)
+  const [allLoadingComplete, setAllLoadingComplete] = useState(false)
+  const [hcHpCalculationTrigger, setHcHpCalculationTrigger] = useState(0)
+  const [, setHcHpCalculationComplete] = useState(false)
+  const [dataLimitWarning, setDataLimitWarning] = useState<string | null>(null)
+  const [isDarkMode, setIsDarkMode] = useState(false)
+  const [isInitialLoadingFromCache, setIsInitialLoadingFromCache] = useState(false)
+  const [isLoadingExiting, setIsLoadingExiting] = useState(false)
+  const [isInfoSectionExpanded, setIsInfoSectionExpanded] = useState(true)
+  const [isInitializing, setIsInitializing] = useState(true)
+
+  // Reset all display states when PDL changes
+  useEffect(() => {
+    logger.log('[Consumption] PDL changed, resetting display states')
+    setIsChartsExpanded(false)
+    setIsStatsSectionExpanded(false)
+    setIsDetailSectionExpanded(false)
+    setIsPowerSectionExpanded(false)
+    setDailyLoadingComplete(false)
+    setPowerLoadingComplete(false)
+    setAllLoadingComplete(false)
+    setDateRange(null)
+    setDetailWeekOffset(0)
+    setLoadingProgress({ current: 0, total: 0, currentRange: '' })
+    setIsInitialLoadingFromCache(false)
+    setIsLoadingExiting(false)
+    setIsInfoSectionExpanded(true)
+    setIsInitializing(true)
+  }, [selectedPDL])
+
+  // Detect dark mode
+  useEffect(() => {
+    const checkDarkMode = () => {
+      setIsDarkMode(document.documentElement.classList.contains('dark'))
+    }
+    checkDarkMode()
+    const observer = new MutationObserver(checkDarkMode)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  // End initialization after cache has time to hydrate
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsInitializing(false)
+    }, 100) // Short delay for cache hydration
+    return () => clearTimeout(timer)
+  }, [selectedPDL])
+
+  // Calculate detail date range
+  // Use LOCAL time for user's perspective (France timezone)
+  const detailDateRange = useMemo(() => {
+    if (!dateRange) return null
+
+    const now = new Date()
+    const yesterday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - 1,
+      12, 0, 0, 0  // Use noon to avoid DST edge cases
+    )
+
+    const offsetDays = detailWeekOffset * 7
+
+    let endDate_obj = new Date(
+      yesterday.getFullYear(),
+      yesterday.getMonth(),
+      yesterday.getDate() - offsetDays,
+      12, 0, 0, 0
+    )
+
+    if (endDate_obj > yesterday) {
+      endDate_obj = new Date(yesterday)
+    }
+
+    const startDate_obj = new Date(
+      endDate_obj.getFullYear(),
+      endDate_obj.getMonth(),
+      endDate_obj.getDate() - 6,
+      12, 0, 0, 0
+    )
+
+    const startDate = startDate_obj.getFullYear() + '-' +
+                      String(startDate_obj.getMonth() + 1).padStart(2, '0') + '-' +
+                      String(startDate_obj.getDate()).padStart(2, '0')
+    const endDate = endDate_obj.getFullYear() + '-' +
+                    String(endDate_obj.getMonth() + 1).padStart(2, '0') + '-' +
+                    String(endDate_obj.getDate()).padStart(2, '0')
+
+    return { start: startDate, end: endDate }
+  }, [dateRange, detailWeekOffset])
+
+  // Use custom hooks
+  const {
+    activePdls: allActivePdls,
+    selectedPDLDetails,
+    consumptionData,
+    maxPowerData,
+    detailData,
+    isLoadingConsumption,
+    isLoadingPower,
+    isLoadingDetail,
+    queryClient
+  } = useConsumptionData(selectedPDL, dateRange, detailDateRange)
+
+  // Filter PDLs to only show those with consumption capability
+  const activePdls = useMemo(() => {
+    return allActivePdls.filter(pdl => pdl.has_consumption === true)
+  }, [allActivePdls])
+
+  const {
+    chartData,
+    powerByYearData,
+    detailByDayData,
+    hcHpByYear,
+    monthlyHcHpByYear
+  } = useConsumptionCalcs({
+    consumptionData,
+    maxPowerData,
+    detailData,
+    selectedPDL,
+    selectedPDLDetails,
+    hcHpCalculationTrigger,
+    detailDateRange
+  })
+
+  const { clearCache } = useConsumptionFetch({
+    selectedPDL,
+    selectedPDLDetails,
+    setDateRange,
+    setIsChartsExpanded,
+    setIsDetailSectionExpanded,
+    setIsStatsSectionExpanded,
+    setIsPowerSectionExpanded,
+    setHcHpCalculationComplete,
+    setDailyLoadingComplete,
+    setPowerLoadingComplete,
+    setAllLoadingComplete,
+    setIsLoadingDetailed,
+    setLoadingProgress,
+    setHcHpCalculationTrigger,
+    setIsClearingCache,
+  })
+
+  // NOTE: Fetch function registration is now handled by the unified hook in PageHeader
+  // We don't register fetchConsumptionData here to avoid conflicts and infinite loops
+  // The PageHeader component uses useUnifiedDataFetch which fetches all data types
+
+  // Check if ANY consumption data is in cache (to determine if we should auto-load)
+  // Use state to track cache instead of useMemo for better reactivity
+  const [cacheCheckTrigger, setCacheCheckTrigger] = useState(0)
+
+  const hasDataInCache = useMemo(() => {
+    // Force recalculation by depending on cacheCheckTrigger
+    void cacheCheckTrigger
+
+    if (!selectedPDL) return false
+
+    // Check for consumptionDetail data (unified cache key)
+    const detailQuery = queryClient.getQueryCache().find({
+      queryKey: ['consumptionDetail', selectedPDL],
+    })
+
+    if (detailQuery?.state.data) {
+      const data = detailQuery.state.data as any
+      const readings = data?.data?.meter_reading?.interval_reading
+      if (readings && readings.length > 0) {
+        logger.log('[Cache] ✓ Found consumptionDetail:', readings.length, 'points')
+        return true
+      }
+    }
+
+    // Also check daily consumption data (unified cache key)
+    const dailyQuery = queryClient.getQueryCache().find({
+      queryKey: ['consumptionDaily', selectedPDL],
+    })
+
+    if (dailyQuery?.state.data) {
+      const data = dailyQuery.state.data as any
+      const readings = data?.data?.meter_reading?.interval_reading
+      if (readings && readings.length > 0) {
+        logger.log('[Cache] ✓ Found consumptionDaily:', readings.length, 'days')
+        return true
+      }
+    }
+
+    return false
+  }, [selectedPDL, queryClient, cacheCheckTrigger])
+
+  // Poll for cache updates every 500ms for 5 seconds after component mount
+  // This catches data fetched by the header button
+  useEffect(() => {
+    let pollCount = 0
+    const maxPolls = 10 // 5 seconds total
+
+    const interval = setInterval(() => {
+      pollCount++
+      setCacheCheckTrigger(prev => prev + 1)
+
+      if (pollCount >= maxPolls || hasDataInCache) {
+        clearInterval(interval)
+      }
+    }, 500)
+
+    return () => clearInterval(interval)
+  }, [selectedPDL]) // Re-run when PDL changes
+
+  // Auto-set selectedPDL when there's only one active PDL
+  useEffect(() => {
+    if (activePdls.length > 0 && !selectedPDL) {
+      setSelectedPDL(activePdls[0].usage_point_id)
+    }
+  }, [activePdls, selectedPDL])
+
+  // Check data limits
+  useEffect(() => {
+    if (selectedPDLDetails) {
+      if (!selectedPDLDetails.has_consumption) {
+        setDataLimitWarning("Ce PDL n'a pas l'option consommation activée. Seules les données de puissance maximum peuvent être récupérées.")
+      } else {
+        setDataLimitWarning(null)
+      }
+    }
+  }, [selectedPDLDetails])
+
+  // Track loading completion
+  useEffect(() => {
+    if (consumptionData && !isLoadingConsumption) {
+      setIsLoadingDaily(false)
+      setDailyLoadingComplete(true)
+    }
+  }, [consumptionData, isLoadingConsumption])
+
+  useEffect(() => {
+    if (maxPowerData && !isLoadingPower) {
+      setPowerLoadingComplete(true)
+    }
+  }, [maxPowerData, isLoadingPower])
+
+  useEffect(() => {
+    if (dailyLoadingComplete && powerLoadingComplete && !isLoadingDetailed) {
+      setAllLoadingComplete(true)
+      setIsChartsExpanded(true)
+      setIsStatsSectionExpanded(true)
+      setIsDetailSectionExpanded(true)
+      setIsPowerSectionExpanded(true)
+    }
+  }, [dailyLoadingComplete, powerLoadingComplete, isLoadingDetailed])
+
+  // Trigger HC/HP calculation
+  useEffect(() => {
+    if (hcHpCalculationTrigger > 0 && selectedPDLDetails?.offpeak_hours) {
+      setTimeout(() => {
+        setHcHpCalculationComplete(true)
+      }, 500)
+    }
+  }, [hcHpCalculationTrigger, selectedPDLDetails])
+
+  // Auto-load dateRange from cache when page loads (ALWAYS if cache exists)
+  // This runs when cache is detected OR when new data arrives
+  useEffect(() => {
+    // Only set dateRange if it's null and we have cache
+    if (!dateRange && selectedPDL && hasDataInCache) {
+      logger.log('[Auto-load] No dateRange set but cache detected - setting dateRange from cache')
+
+      // Show loading overlay while hydrating cache data
+      setIsInitialLoadingFromCache(true)
+
+      // Calculate date range (same as in fetchConsumptionData)
+      // Use LOCAL time for user's perspective
+      const now = new Date()
+      const yesterday = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() - 1,
+        12, 0, 0, 0  // Use noon to avoid DST edge cases
+      )
+      const startDate_obj = new Date(
+        yesterday.getFullYear(),
+        yesterday.getMonth(),
+        yesterday.getDate() - 1094,
+        12, 0, 0, 0
+      )
+      const startDate = startDate_obj.getFullYear() + '-' +
+                        String(startDate_obj.getMonth() + 1).padStart(2, '0') + '-' +
+                        String(startDate_obj.getDate()).padStart(2, '0')
+      const endDate = yesterday.getFullYear() + '-' +
+                      String(yesterday.getMonth() + 1).padStart(2, '0') + '-' +
+                      String(yesterday.getDate()).padStart(2, '0')
+
+      logger.log('[Auto-load] Setting date range:', startDate, 'to', endDate)
+
+      setDateRange({ start: startDate, end: endDate })
+
+      // Set loading states to complete so sections expand
+      setTimeout(() => {
+        setDailyLoadingComplete(true)
+        setPowerLoadingComplete(true)
+        setAllLoadingComplete(true)
+        setIsChartsExpanded(true)
+        setIsStatsSectionExpanded(true)
+        setIsDetailSectionExpanded(true)
+        setIsPowerSectionExpanded(true)
+        // Trigger HC/HP calculation for cached data
+        setHcHpCalculationTrigger(prev => prev + 1)
+        // Trigger exit animation
+        setIsLoadingExiting(true)
+        // Hide loading overlay after exit animation completes (300ms)
+        setTimeout(() => {
+          setIsInitialLoadingFromCache(false)
+          setIsLoadingExiting(false)
+        }, 300)
+
+        logger.log('[Auto-load] All states set - graphs should be visible')
+      }, 500) // Small delay to let React Query hydrate and show loading state
+    }
+  }, [selectedPDL, hasDataInCache, dateRange, queryClient])
+
+  // NOTE: Auto-fetch disabled - user must click "Récupérer" button manually
+  // The effect above (Auto-load dateRange from cache) still works to display cached data
+  // without making any API calls
+
+  // Mark daily consumption loading as complete (whether success or error)
+  useEffect(() => {
+    logger.log('[Loading Check] Daily:', { dateRange: !!dateRange, isLoading: isLoadingConsumption, hasData: !!consumptionData })
+    if (dateRange && !isLoadingConsumption && consumptionData) {
+      logger.log('[Loading] ✓ Daily consumption complete')
+      setDailyLoadingComplete(true)
+    }
+  }, [dateRange, isLoadingConsumption, consumptionData])
+
+  // Mark power loading as complete
+  useEffect(() => {
+    logger.log('[Loading Check] Power:', { dateRange: !!dateRange, isLoading: isLoadingPower, hasData: !!maxPowerData })
+    if (dateRange && !isLoadingPower && maxPowerData) {
+      logger.log('[Loading] ✓ Power complete')
+      setPowerLoadingComplete(true)
+    }
+  }, [dateRange, isLoadingPower, maxPowerData])
+
+  // Check if data came from cache, mark as complete immediately
+  useEffect(() => {
+    if (dateRange && !isLoadingConsumption && !isLoadingPower && !isLoadingDetailed &&
+        consumptionData && maxPowerData) {
+      // Data came from cache, mark as complete immediately
+      setDailyLoadingComplete(true)
+      setPowerLoadingComplete(true)
+      setAllLoadingComplete(true)
+    }
+  }, [dateRange, isLoadingConsumption, isLoadingPower, isLoadingDetailed, consumptionData, maxPowerData])
+
+  // Check if all loading is complete (daily, power, and detailed if it was started)
+  useEffect(() => {
+    const dailyAndPowerDone = dailyLoadingComplete && powerLoadingComplete
+    const detailedDone = !isLoadingDetailed || loadingProgress.total === 0
+
+    if (dailyAndPowerDone && detailedDone) {
+      // Wait a bit to show the completed status before hiding
+      const timer = setTimeout(() => {
+        setAllLoadingComplete(true)
+      }, 1000) // 1 second delay
+      return () => clearTimeout(timer)
+    }
+  }, [dailyLoadingComplete, powerLoadingComplete, isLoadingDetailed, loadingProgress.total])
+
+  // Auto-expand all sections when loading is complete (and collapse info section)
+  useEffect(() => {
+    logger.log('[Loading] allLoadingComplete changed:', allLoadingComplete)
+    if (allLoadingComplete) {
+      logger.log('[Loading] ✓ All loading complete - expanding sections, collapsing info')
+      setIsStatsSectionExpanded(true)
+      setIsChartsExpanded(true)
+      setIsDetailSectionExpanded(true)
+      setIsPowerSectionExpanded(true)
+      setIsInfoSectionExpanded(false) // Collapse info section when data is loaded
+    }
+  }, [allLoadingComplete])
+
+  // Mark HC/HP calculation as complete when data is ready
+  useEffect(() => {
+    if (!isLoadingDetailed && hcHpByYear.length > 0) {
+      // Give a small delay to ensure the calculation is fully rendered
+      const timer = setTimeout(() => {
+        setHcHpCalculationComplete(true)
+      }, 500)
+      return () => clearTimeout(timer)
+    } else {
+      setHcHpCalculationComplete(false)
+    }
+  }, [isLoadingDetailed, hcHpByYear.length])
+
+  const confirmClearCache = async () => {
+    setShowConfirmModal(false)
+    await clearCache()
+  }
+
+  // For now, return the simplified version with working components
+  // The rest of the components will be added incrementally
+
+  // Block rendering during initialization to prevent flash of content
+  if (isInitializing) {
+    return <div className="w-full" />
+  }
+
+  // Show loading overlay when loading cached data
+  // Display blurred placeholder content behind the loading spinner
+  if (isInitialLoadingFromCache) {
+    return (
+      <div className="w-full">
+        <LoadingOverlay dataType="consumption" isExiting={isLoadingExiting}>
+          <LoadingPlaceholder type="consumption" />
+        </LoadingOverlay>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full">
+      {/* Warning if PDL has limited data */}
+      {dataLimitWarning && (
+        <div className="mb-6 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center gap-2">
+          <span className="text-blue-600 dark:text-blue-400 text-lg flex-shrink-0">ℹ️</span>
+          <p className="text-sm text-blue-800 dark:text-blue-200">
+            {dataLimitWarning}
+          </p>
+        </div>
+      )}
+
+      {/* Empty State - No data loaded */}
+      {!hasDataInCache && !allLoadingComplete && (
+        <div className="mt-2 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+          <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+            <div className="w-20 h-20 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center mb-6">
+              <Database className="w-10 h-10 text-primary-600 dark:text-primary-400" />
+            </div>
+            <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+              Aucune donnée de consommation
+            </h3>
+            <p className="text-gray-600 dark:text-gray-400 max-w-md mb-6">
+              Pour afficher vos statistiques et graphiques de consommation,
+              lancez la récupération des données en cliquant sur le bouton
+              <span className="font-semibold text-primary-600 dark:text-primary-400"> Récupérer </span>
+              en haut à droite de la page.
+            </p>
+            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+              <span>Sélectionnez un PDL</span>
+              <ArrowRight className="w-4 h-4" />
+              <span>Cliquez sur "Récupérer"</span>
+              <ArrowRight className="w-4 h-4" />
+              <span>Visualisez vos données</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Statistics Section - Collapsible (only show if data is available) */}
+      <AnimatedSection isVisible={hasDataInCache || allLoadingComplete} delay={0}>
+        <div className="mt-2 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+          <div
+            className={`flex items-center justify-between p-6 ${
+              allLoadingComplete ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
+            }`}
+            onClick={() => {
+              if (allLoadingComplete) {
+                setIsStatsSectionExpanded(!isStatsSectionExpanded)
+              }
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <BarChart3 className="text-primary-600 dark:text-primary-400" size={20} />
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Statistiques de consommation
+              </h2>
+            </div>
+            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+              {isStatsSectionExpanded ? (
+                <span className="text-sm">Réduire</span>
+              ) : (
+                <span className="text-sm">Développer</span>
+              )}
+              <svg
+                className={`w-5 h-5 transition-transform duration-200 ${
+                  isStatsSectionExpanded ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </div>
+
+          {isStatsSectionExpanded && allLoadingComplete && (
+            <div className="px-6 pb-6">
+              {/* Yearly Statistics Cards */}
+              <YearlyStatCards
+                chartData={chartData}
+                consumptionData={consumptionData}
+              />
+
+              {/* HC/HP Distribution */}
+              <HcHpDistribution
+                hcHpByYear={hcHpByYear}
+                selectedPDLDetails={selectedPDLDetails}
+              />
+            </div>
+          )}
+        </div>
+      </AnimatedSection>
+
+      {/* Charts Section - Annual Curve */}
+      <AnimatedSection isVisible={hasDataInCache || allLoadingComplete} delay={100}>
+        <div className="mt-6 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+          <div
+            className={`flex items-center justify-between p-6 ${
+              allLoadingComplete ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
+            }`}
+            onClick={() => {
+              if (allLoadingComplete) {
+                setIsChartsExpanded(!isChartsExpanded)
+              }
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <BarChart3 className="text-primary-600 dark:text-primary-400" size={20} />
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Graphiques de consommation
+              </h2>
+            </div>
+            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+              {isChartsExpanded ? (
+                <span className="text-sm">Réduire</span>
+              ) : (
+                <span className="text-sm">Développer</span>
+              )}
+              <svg
+                className={`w-5 h-5 transition-transform duration-200 ${
+                  isChartsExpanded ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </div>
+
+          {isChartsExpanded && allLoadingComplete && (
+            <div className="px-6 pb-6 space-y-8">
+              {/* Yearly Consumption by Month */}
+              <YearlyConsumption
+                chartData={chartData}
+                consumptionData={consumptionData}
+                isDarkMode={isDarkMode}
+              />
+
+              {/* Annual Curve */}
+              <AnnualCurve
+                chartData={chartData}
+                isDarkMode={isDarkMode}
+              />
+            </div>
+          )}
+        </div>
+      </AnimatedSection>
+
+      {/* Detailed Consumption Section */}
+      <AnimatedSection isVisible={hasDataInCache || allLoadingComplete} delay={200}>
+        <div className="mt-6 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+          <div
+            className={`flex items-center justify-between p-6 ${
+              allLoadingComplete && detailByDayData.length > 0 ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
+            }`}
+            onClick={() => {
+              if (allLoadingComplete && detailByDayData.length > 0) {
+                setIsDetailSectionExpanded(!isDetailSectionExpanded)
+              }
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <BarChart3 className="text-primary-600 dark:text-primary-400" size={20} />
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Courbe de charge détaillée
+              </h2>
+            </div>
+            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+              {isDetailSectionExpanded ? (
+                <span className="text-sm">Réduire</span>
+              ) : (
+                <span className="text-sm">Développer</span>
+              )}
+              <svg
+                className={`w-5 h-5 transition-transform duration-200 ${
+                  isDetailSectionExpanded ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </div>
+
+          {isDetailSectionExpanded && allLoadingComplete && detailByDayData.length > 0 && (
+            <div className="px-6 pb-6 space-y-8">
+              {/* Detailed Load Curve */}
+              <DetailedCurve
+                cacheKeyPrefix="consumptionDetail"
+                curveName="Consommation"
+                detailByDayData={detailByDayData}
+                selectedPDL={selectedPDL}
+                isDarkMode={isDarkMode}
+                isLoadingDetail={isLoadingDetail}
+                detailDateRange={detailDateRange}
+                onWeekOffsetChange={setDetailWeekOffset}
+                detailWeekOffset={detailWeekOffset}
+              />
+
+              {/* Monthly HC/HP */}
+              <MonthlyHcHp
+                monthlyHcHpByYear={monthlyHcHpByYear}
+                selectedPDLDetails={selectedPDLDetails}
+                isDarkMode={isDarkMode}
+              />
+
+              {/* Info note */}
+              {detailByDayData.length > 0 && (
+                <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+                  <p className="text-sm text-blue-800 dark:text-blue-200">
+                    <strong>ℹ️ Note :</strong> Ces graphiques montrent votre consommation électrique détaillée avec des mesures à intervalles réguliers
+                    ({detailData?.meter_reading?.reading_type?.interval_length === 'P30M' ? '30 minutes' :
+                      detailData?.meter_reading?.reading_type?.interval_length === 'P15M' ? '15 minutes' :
+                      detailData?.meter_reading?.reading_type?.interval_length || 'variables'})
+                    pour les 7 derniers jours.
+                    Cela vous permet d'identifier précisément vos pics de consommation et d'optimiser votre utilisation.
+                    <br/><br/>
+                    <strong>💡 Calcul :</strong> Les valeurs sont en puissance moyenne (kW) pour chaque intervalle.
+                    L'énergie consommée pendant l'intervalle est calculée en tenant compte de la durée
+                    (Énergie = Puissance × Durée). Le total journalier affiché dans les onglets correspond à la somme
+                    de tous les intervalles de la journée.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </AnimatedSection>
+
+      {/* Max Power Section */}
+      <AnimatedSection isVisible={hasDataInCache || allLoadingComplete} delay={300}>
+        <div className="mt-6 rounded-xl shadow-md border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 transition-colors duration-200">
+          <div
+            className={`flex items-center justify-between p-6 ${
+              allLoadingComplete ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
+            }`}
+            onClick={() => {
+              if (allLoadingComplete) {
+                setIsPowerSectionExpanded(!isPowerSectionExpanded)
+              }
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <TrendingUp className="text-primary-600 dark:text-primary-400" size={20} />
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Pics de puissance maximale</h2>
+            </div>
+            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+              {isPowerSectionExpanded ? (
+                <span className="text-sm">Réduire</span>
+              ) : (
+                <span className="text-sm">Développer</span>
+              )}
+              <svg
+                className={`w-5 h-5 transition-transform duration-200 ${
+                  isPowerSectionExpanded ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </div>
+
+          {isPowerSectionExpanded && allLoadingComplete && powerByYearData.length > 0 && (
+            <div className="px-6 pb-6">
+              <PowerPeaks
+                powerByYearData={powerByYearData}
+                selectedPDLDetails={selectedPDLDetails}
+                isDarkMode={isDarkMode}
+              />
+            </div>
+          )}
+        </div>
+      </AnimatedSection>
+
+
+      {/* Info Block Component - Always visible, collapsible */}
+      <InfoBlock
+        isExpanded={isInfoSectionExpanded}
+        onToggle={() => setIsInfoSectionExpanded(!isInfoSectionExpanded)}
+      />
+
+      {/* Confirm Modal Component */}
+      <ConfirmModal
+        showConfirmModal={showConfirmModal}
+        setShowConfirmModal={setShowConfirmModal}
+        confirmClearCache={confirmClearCache}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/ConsumptionKwh/types/consumption.types.ts
+++ b/apps/web/src/pages/ConsumptionKwh/types/consumption.types.ts
@@ -1,0 +1,199 @@
+import type { PDL } from '@/types/api'
+
+// Date range type
+export interface DateRange {
+  start: string
+  end: string
+}
+
+// Loading progress
+export interface LoadingProgress {
+  current: number
+  total: number
+  currentRange: string
+}
+
+// Chart data types
+export interface ChartDataPoint {
+  date: string
+  value: number
+  hc?: number
+  hp?: number
+  year?: number
+  month?: string
+}
+
+export interface PowerDataPoint {
+  date: string
+  value: number
+}
+
+export interface DetailDataPoint {
+  date: string
+  time: string
+  value: number
+  isHc?: boolean
+}
+
+export interface HcHpData {
+  hc: number
+  hp: number
+  total: number
+  percentHc: number
+  percentHp: number
+}
+
+export interface YearlyData {
+  year: number
+  total: number
+  hc?: number
+  hp?: number
+  percentHc?: number
+  percentHp?: number
+}
+
+export interface MonthlyHcHpData {
+  month: string
+  hc: number
+  hp: number
+  total: number
+}
+
+// API response types
+export interface ConsumptionResponse {
+  success: boolean
+  data?: any
+  error?: string
+  message?: string
+}
+
+// Meter reading data structure from Enedis API
+export interface MeterReading {
+  usage_point_id?: string
+  start?: string
+  end?: string
+  reading_type?: {
+    aggregate?: string
+    unit?: string
+    interval_length?: string
+    measurement_kind?: string
+  }
+  interval_reading?: Array<{
+    date: string
+    value: string | number
+  }>
+}
+
+// API response with meter reading data
+export interface ConsumptionAPIResponse {
+  meter_reading?: MeterReading
+}
+
+export interface MaxPowerAPIResponse {
+  meter_reading?: MeterReading
+}
+
+export interface DetailAPIResponse {
+  meter_reading?: MeterReading
+}
+
+// Component props types
+export interface PDLSelectorProps {
+  pdls: PDL[]
+  activePdls: PDL[]
+  selectedPDL: string
+  selectedPDLDetails: PDL | undefined
+  onPDLSelect: (value: string) => void
+  onFetchData: () => void
+  onClearCache: () => void
+  isClearingCache: boolean
+  isLoading: boolean
+  isLoadingDetailed: boolean
+  isLoadingDaily: boolean
+  hasAttemptedAutoLoad: boolean
+}
+
+export interface LoadingProgressProps {
+  isLoadingDaily: boolean
+  isLoadingDetailed: boolean
+  dailyLoadingComplete: boolean
+  powerLoadingComplete: boolean
+  loadingProgress: LoadingProgress
+  hcHpCalculationComplete: boolean
+  hcHpCalculationTrigger: number
+  allLoadingComplete: boolean
+}
+
+export interface YearlyConsumptionProps {
+  yearConsumptions: YearlyData[]
+  selectedHcHpPeriod: number
+  setSelectedHcHpPeriod: (value: number) => void
+  showYearComparison: boolean
+  setShowYearComparison: (value: boolean) => void
+  isStatsSectionExpanded: boolean
+  setIsStatsSectionExpanded: (value: boolean) => void
+  isDarkMode: boolean
+}
+
+export interface HcHpDistributionProps {
+  hcHpByYear: Record<number, HcHpData>
+  selectedHcHpPeriod: number
+  isDarkMode: boolean
+}
+
+export interface AnnualCurveProps {
+  chartData: ChartDataPoint[]
+  onExportJSON: () => void
+  isChartsExpanded: boolean
+  setIsChartsExpanded: (value: boolean) => void
+  isDarkMode: boolean
+}
+
+export interface DetailedLoadCurveProps {
+  detailChartData: DetailDataPoint[]
+  detailHcHpChartData: DetailDataPoint[]
+  selectedDetailDay: number
+  setSelectedDetailDay: (value: number) => void
+  detailWeekOffset: number
+  setDetailWeekOffset: (value: number) => void
+  viewMonth: Date
+  setViewMonth: (value: Date) => void
+  showDatePicker: boolean
+  setShowDatePicker: (value: boolean) => void
+  showDetailYearComparison: boolean
+  setShowDetailYearComparison: (value: boolean) => void
+  showDetailWeekComparison: boolean
+  setShowDetailWeekComparison: (value: boolean) => void
+  dateRange: DateRange | null
+  detailDateRange: DateRange | null
+  isDetailSectionExpanded: boolean
+  setIsDetailSectionExpanded: (value: boolean) => void
+  isDarkMode: boolean
+  selectedPDLDetails: PDL | undefined
+}
+
+export interface MonthlyHcHpProps {
+  monthlyHcHpData: Record<number, MonthlyHcHpData[]>
+  selectedMonthlyHcHpYear: number
+  setSelectedMonthlyHcHpYear: (value: number) => void
+  isDarkMode: boolean
+}
+
+export interface PowerPeaksProps {
+  powerChartData: PowerDataPoint[]
+  selectedPowerYear: number
+  setSelectedPowerYear: (value: number) => void
+  isPowerSectionExpanded: boolean
+  setIsPowerSectionExpanded: (value: boolean) => void
+  isDarkMode: boolean
+}
+
+export interface InfoBlockProps {
+  dataLimitWarning: string | null
+}
+
+export interface ConfirmModalProps {
+  showConfirmModal: boolean
+  setShowConfirmModal: (value: boolean) => void
+  confirmClearCache: () => void
+}

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { ArrowRight, Shield, Zap, Key, Moon, Sun, Heart, Lock, Database, BarChart3, RefreshCw, ChevronDown, Sparkles, TrendingUp, Github, Server, Home, Radio, LineChart, Container } from 'lucide-react'
+import { ArrowRight, Shield, Zap, Key, Moon, Sun, Heart, Lock, Database, BarChart3, RefreshCw, ChevronDown, Sparkles, TrendingUp, Github, Server, Home, Radio, LineChart, Container, AlertCircle, UserPlus, ExternalLink } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useThemeStore } from '@/stores/themeStore'
 import { useState, useEffect, useRef } from 'react'
@@ -229,9 +229,15 @@ function scrollToNextSection() {
 }
 
 export default function Landing() {
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, isLoading } = useAuth()
   const { isDark, toggleTheme } = useThemeStore()
   const [showHeader, setShowHeader] = useState(false)
+  const [isReady, setIsReady] = useState(false)
+
+  // Attendre que le composant soit monté pour éviter le clignotement
+  useEffect(() => {
+    setIsReady(true)
+  }, [])
 
   // Animation du texte hero
   const [heroText, setHeroText] = useState('')
@@ -323,13 +329,13 @@ export default function Landing() {
               >
                 {isDark ? <Sun size={18} /> : <Moon size={18} />}
               </button>
-              {!isAuthenticated && (
+              {isReady && !isLoading && !isAuthenticated && (
                 <Link to="/login" className="btn btn-secondary text-sm sm:text-base px-3 sm:px-4 hover:scale-105 transition-transform duration-300">
                   <span className="hidden sm:inline">Se connecter</span>
                   <span className="sm:hidden">Connexion</span>
                 </Link>
               )}
-              {isAuthenticated && (
+              {isReady && !isLoading && isAuthenticated && (
                 <Link to="/dashboard" className="btn btn-primary text-sm sm:text-base px-3 sm:px-4 hover:scale-105 transition-transform duration-300">
                   Dashboard
                 </Link>
@@ -349,7 +355,7 @@ export default function Landing() {
         <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-blue-300/10 dark:bg-blue-600/5 rounded-full blur-3xl animate-pulse" style={{ animationDelay: '1s' }} />
 
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div className="animate-fade-in-up">
+          <div>
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 mb-6 animate-bounce-subtle">
               <Sparkles size={16} />
               <span className="text-sm font-medium">100% Gratuit & Open Source</span>
@@ -360,12 +366,12 @@ export default function Landing() {
               <span className="animate-blink">|</span>
             </h1>
 
-            <p className="text-lg sm:text-xl lg:text-2xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed animate-fade-in" style={{ animationDelay: '0.5s' }}>
+            <p className="text-lg sm:text-xl lg:text-2xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed">
               <span className="bg-gradient-to-r from-green-500 via-emerald-500 to-teal-500 bg-clip-text text-transparent font-bold">MyElectricalData</span> est une <span className="text-primary-600 dark:text-primary-400 font-semibold">passerelle intelligente</span> qui permet à n'importe quel particulier d'accéder à ses données de consommation/production d'électricité disponibles chez Enedis.
             </p>
 
-            {isAuthenticated ? (
-              <div className="flex justify-center animate-fade-in" style={{ animationDelay: '1s' }}>
+            {isReady && !isLoading && isAuthenticated ? (
+              <div className="flex justify-center">
                 <Link
                   to="/dashboard"
                   className="group btn btn-primary text-lg px-8 py-4 inline-flex items-center gap-2 hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl"
@@ -374,8 +380,8 @@ export default function Landing() {
                   <ArrowRight className="group-hover:translate-x-1 transition-transform duration-300" size={20} />
                 </Link>
               </div>
-            ) : (
-              <div className="flex flex-col sm:flex-row justify-center gap-4 animate-fade-in" style={{ animationDelay: '1s' }}>
+            ) : isReady && !isLoading ? (
+              <div className="flex flex-col sm:flex-row justify-center gap-4">
                 <Link
                   to="/signup"
                   className="group btn btn-primary text-lg px-8 py-4 inline-flex items-center justify-center gap-2 hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl"
@@ -390,7 +396,7 @@ export default function Landing() {
                   Se connecter
                 </Link>
               </div>
-            )}
+            ) : null}
           </div>
 
         </div>
@@ -470,9 +476,51 @@ export default function Landing() {
         }`}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl sm:text-4xl font-bold text-center mb-16 text-gray-900 dark:text-white">
+          <h2 className="text-3xl sm:text-4xl font-bold text-center mb-8 text-gray-900 dark:text-white">
             Comment ça marche ?
           </h2>
+
+          {/* Alerte importante : deux comptes distincts */}
+          <div className="max-w-4xl mx-auto mb-12 p-6 bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 rounded-2xl border-2 border-amber-300 dark:border-amber-700 shadow-lg">
+            <div className="flex items-start gap-4">
+              <div className="flex-shrink-0">
+                <AlertCircle className="text-amber-600 dark:text-amber-400" size={32} />
+              </div>
+              <div>
+                <h3 className="text-xl font-bold mb-3 text-gray-900 dark:text-white flex items-center gap-2">
+                  <span>Deux comptes distincts</span>
+                </h3>
+                <div className="space-y-4 text-gray-700 dark:text-gray-300">
+                  <p className="text-lg leading-relaxed">
+                    Votre compte <strong className="text-primary-600 dark:text-primary-400">MyElectricalData</strong> est <strong className="text-amber-700 dark:text-amber-400">totalement indépendant</strong> de votre compte Enedis. Ce sont deux comptes séparés avec des identifiants différents.
+                  </p>
+                  <div className="grid md:grid-cols-2 gap-4 mt-4">
+                    <div className="p-4 bg-white dark:bg-gray-800 rounded-xl border border-primary-200 dark:border-primary-700">
+                      <div className="flex items-center gap-2 mb-2">
+                        <UserPlus className="text-primary-600 dark:text-primary-400" size={20} />
+                        <span className="font-semibold text-primary-700 dark:text-primary-400">Compte MyElectricalData</span>
+                      </div>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        Créé sur cette plateforme avec votre email. Vous obtenez des identifiants API (client_id / client_secret) pour accéder à vos données.
+                      </p>
+                    </div>
+                    <div className="p-4 bg-white dark:bg-gray-800 rounded-xl border border-green-200 dark:border-green-700">
+                      <div className="flex items-center gap-2 mb-2">
+                        <ExternalLink className="text-green-600 dark:text-green-400" size={20} />
+                        <span className="font-semibold text-green-700 dark:text-green-400">Compte Enedis</span>
+                      </div>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        Votre compte personnel sur le site Enedis. Utilisé lors du consentement pour autoriser l'accès à vos données Linky.
+                      </p>
+                    </div>
+                  </div>
+                  <p className="text-base mt-4 p-3 bg-amber-100 dark:bg-amber-900/30 rounded-lg">
+                    <strong className="text-amber-700 dark:text-amber-400">📋 Processus :</strong> Créez d'abord votre compte MyElectricalData, puis lors du consentement vous serez redirigé vers le site officiel d'Enedis où vous vous connecterez avec <em>vos identifiants Enedis</em> pour autoriser l'accès.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <div className="relative">
             {/* Timeline line */}
@@ -489,10 +537,13 @@ export default function Landing() {
                   <div className="inline-block p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 transform hover:scale-105 border border-gray-200 dark:border-gray-700">
                     <h3 className="text-2xl font-bold mb-3 text-gray-900 dark:text-white flex items-center justify-center md:justify-end gap-2">
                       <Key className="text-primary-600 dark:text-primary-400" size={28} />
-                      Création de compte
+                      Création de compte MyElectricalData
                     </h3>
                     <p className="text-gray-600 dark:text-gray-400 text-lg">
-                      Créez votre compte et obtenez vos identifiants API (client_id et client_secret).
+                      Créez votre compte <strong>sur notre plateforme</strong> et obtenez vos identifiants API (client_id et client_secret).
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-500 mt-2 italic">
+                      Ce compte est distinct de votre compte Enedis.
                     </p>
                   </div>
                 </div>
@@ -522,7 +573,11 @@ export default function Landing() {
                       Consentement Enedis
                     </h3>
                     <p className="text-gray-600 dark:text-gray-400 text-lg">
-                      Autorisez la passerelle à accéder à vos données via le portail officiel Enedis.
+                      Vous êtes redirigé vers le <strong>site officiel Enedis</strong> où vous vous connectez avec <strong>votre compte Enedis personnel</strong> pour autoriser l'accès à vos données.
+                    </p>
+                    <p className="text-sm text-green-600 dark:text-green-400 mt-2 flex items-center justify-center md:justify-start gap-1">
+                      <ExternalLink size={14} />
+                      Connexion sécurisée sur enedis.fr
                     </p>
                   </div>
                 </div>
@@ -939,7 +994,7 @@ export default function Landing() {
           <p className="text-xl lg:text-2xl text-white/90 mb-10 leading-relaxed">
             Créez votre compte gratuitement et obtenez vos identifiants API en quelques minutes.
           </p>
-          {isAuthenticated ? (
+          {isReady && !isLoading && isAuthenticated ? (
             <Link
               to="/dashboard"
               className="group inline-flex items-center gap-3 px-10 py-5 bg-white text-primary-600 rounded-xl font-bold text-xl hover:bg-gray-50 transition-all duration-300 shadow-2xl hover:shadow-3xl hover:scale-105"
@@ -947,7 +1002,7 @@ export default function Landing() {
               Accéder au dashboard
               <ArrowRight className="group-hover:translate-x-2 transition-transform duration-300" size={24} />
             </Link>
-          ) : (
+          ) : isReady && !isLoading ? (
             <Link
               to="/signup"
               className="group inline-flex items-center gap-3 px-10 py-5 bg-white text-primary-600 rounded-xl font-bold text-xl hover:bg-gray-50 transition-all duration-300 shadow-2xl hover:shadow-3xl hover:scale-105"
@@ -955,7 +1010,7 @@ export default function Landing() {
               Créer mon compte gratuitement
               <ArrowRight className="group-hover:translate-x-2 transition-transform duration-300" size={24} />
             </Link>
-          )}
+          ) : null}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- Added submenu with kWh and Euro tabs to the consumption page
- Restructured routes: /consumption redirects to /consumption_kwh
- Created ConsumptionEuro page as a coming-soon placeholder
- Updated navigation, page header, and PDL filtering logic for consumption pages

## Test Plan

- Navigate to /consumption_kwh to see the new kWh tab (active)
- Click the Euro tab to view the coming-soon page
- Verify the menu highlights "Consommation" when on either tab
- Test PDL selector filters correctly for consumption pages

🤖 Generated with Claude Code