### PR TITLE
Implement Alembic for database migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,14 @@ make watch            # Start backend file watcher
 make stop-watch       # Stop backend file watcher
 
 # Database
-make db-shell         # Access PostgreSQL shell
-make db-backup        # Backup database
-make migrate          # Apply database migrations
+make db-shell            # Access PostgreSQL shell
+make db-backup           # Backup database
+make migrate             # Apply all pending migrations
+make migrate-downgrade   # Rollback last migration
+make migrate-history     # Show migration history
+make migrate-current     # Show current migration revision
+make migrate-revision    # Generate a new migration (autogenerate)
+make migrate-stamp       # Stamp database with current revision
 
 # Maintenance
 make logs             # Show all logs
@@ -99,15 +104,32 @@ uv run black src tests
 uv run ruff check --fix src tests
 ```
 
-**Database Migration:**
+**Database Migration (Alembic):**
 
 ```bash
 # Auto-detect: SQLite (default) or PostgreSQL based on DATABASE_URL
 # SQLite: sqlite+aiosqlite:///./data/myelectricaldata.db
 # PostgreSQL: postgresql+asyncpg://user:pass@postgres:5432/db
 
-# Migration scripts in apps/api/migrations/
-docker compose exec backend python /app/migrations/migration_name.py
+# Apply all pending migrations
+docker compose exec backend alembic upgrade head
+
+# Rollback last migration
+docker compose exec backend alembic downgrade -1
+
+# Show migration history
+docker compose exec backend alembic history
+
+# Generate a new migration (after modifying models)
+docker compose exec backend alembic revision --autogenerate -m "Description"
+
+# For existing databases, stamp with current revision
+docker compose exec backend alembic stamp head
+
+# Local development (from apps/api/)
+cd apps/api
+uv run alembic upgrade head
+uv run alembic revision --autogenerate -m "Description"
 ```
 
 ### Frontend (apps/web/)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -40,8 +40,11 @@ COPY --from=deps /usr/local/bin /usr/local/bin
 # Copy application code (changes frequently - last layer)
 COPY . .
 
+# Make entrypoint executable
+RUN chmod +x /app/entrypoint.sh
+
 # Expose port
 EXPOSE 8000
 
-# Start the application directly with uvicorn
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Start with entrypoint (runs migrations then uvicorn)
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run test lint format clean sync
+.PHONY: install run test lint format clean sync migrate migrate-upgrade migrate-downgrade migrate-revision migrate-history migrate-current
 
 install:
 	uv sync
@@ -30,3 +30,25 @@ clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 	rm -rf .pytest_cache .coverage htmlcov .mypy_cache .venv
+
+# Alembic migrations
+migrate: migrate-upgrade
+
+migrate-upgrade:
+	uv run alembic upgrade head
+
+migrate-downgrade:
+	uv run alembic downgrade -1
+
+migrate-revision:
+	@read -p "Enter migration message: " msg; \
+	uv run alembic revision --autogenerate -m "$$msg"
+
+migrate-history:
+	uv run alembic history
+
+migrate-current:
+	uv run alembic current
+
+migrate-stamp-head:
+	uv run alembic stamp head

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,94 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+# version_path_separator = newline
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# SQLAlchemy URL - read from environment variable DATABASE_URL
+# This is overridden in env.py to use the settings
+sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+hooks = black
+black.type = console_scripts
+black.entrypoint = black
+black.options = -q
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apps/api/alembic/README
+++ b/apps/api/alembic/README
@@ -1,0 +1,25 @@
+Generic single-database configuration with async support.
+
+This Alembic environment is configured for async SQLAlchemy with support for both
+PostgreSQL (asyncpg) and SQLite (aiosqlite).
+
+Usage:
+    # Generate a new migration
+    cd apps/api
+    alembic revision --autogenerate -m "Description of changes"
+
+    # Apply all migrations
+    alembic upgrade head
+
+    # Rollback one migration
+    alembic downgrade -1
+
+    # Show current revision
+    alembic current
+
+    # Show migration history
+    alembic history
+
+Docker Usage:
+    docker compose exec backend alembic upgrade head
+    docker compose exec backend alembic revision --autogenerate -m "Description"

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,0 +1,98 @@
+import asyncio
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+# Add src to path for imports
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+# Import models and config
+from config import settings
+from models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Override sqlalchemy.url with our settings
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/alembic/script.py.mako
+++ b/apps/api/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/apps/api/alembic/versions/20251201_0100_001_initial_schema.py
+++ b/apps/api/alembic/versions/20251201_0100_001_initial_schema.py
@@ -1,0 +1,287 @@
+"""Initial schema baseline
+
+Revision ID: 001
+Revises:
+Create Date: 2025-12-01 01:00:00
+
+This is a baseline migration that represents the current state of the database.
+It uses CREATE TABLE IF NOT EXISTS and ADD COLUMN IF NOT EXISTS to be idempotent.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Get the connection and check the dialect
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        # PostgreSQL - use IF NOT EXISTS for idempotent migrations
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS roles (
+                id VARCHAR(36) PRIMARY KEY,
+                name VARCHAR(50) NOT NULL UNIQUE,
+                display_name VARCHAR(100) NOT NULL,
+                description VARCHAR(255),
+                is_system BOOLEAN NOT NULL DEFAULT FALSE,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS permissions (
+                id VARCHAR(36) PRIMARY KEY,
+                name VARCHAR(100) NOT NULL UNIQUE,
+                display_name VARCHAR(100) NOT NULL,
+                description VARCHAR(255),
+                resource VARCHAR(50) NOT NULL,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS role_permissions (
+                role_id VARCHAR(36) NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+                permission_id VARCHAR(36) NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+                PRIMARY KEY (role_id, permission_id)
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id VARCHAR(36) PRIMARY KEY,
+                email VARCHAR(255) NOT NULL UNIQUE,
+                hashed_password VARCHAR(255) NOT NULL,
+                client_id VARCHAR(64) NOT NULL UNIQUE,
+                client_secret VARCHAR(128) NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                is_admin BOOLEAN NOT NULL DEFAULT FALSE,
+                email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+                debug_mode BOOLEAN NOT NULL DEFAULT FALSE,
+                enedis_customer_id VARCHAR(64),
+                role_id VARCHAR(36) REFERENCES roles(id),
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS pdls (
+                id VARCHAR(36) PRIMARY KEY,
+                usage_point_id VARCHAR(14) NOT NULL UNIQUE,
+                user_id VARCHAR(36) NOT NULL REFERENCES users(id),
+                name VARCHAR(100),
+                display_order INTEGER,
+                subscribed_power INTEGER,
+                offpeak_hours JSONB,
+                pricing_option VARCHAR(50),
+                has_consumption BOOLEAN NOT NULL DEFAULT TRUE,
+                has_production BOOLEAN NOT NULL DEFAULT FALSE,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                oldest_available_data_date DATE,
+                activation_date DATE,
+                linked_production_pdl_id VARCHAR(36) REFERENCES pdls(id),
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS tokens (
+                id VARCHAR(36) PRIMARY KEY,
+                user_id VARCHAR(36) REFERENCES users(id),
+                usage_point_id VARCHAR(14) NOT NULL,
+                access_token TEXT NOT NULL,
+                refresh_token TEXT,
+                token_type VARCHAR(50) NOT NULL,
+                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                scope TEXT,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                CONSTRAINT uq_user_usage_point UNIQUE (user_id, usage_point_id)
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS email_verification_tokens (
+                id VARCHAR(36) PRIMARY KEY,
+                user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                token VARCHAR(64) NOT NULL UNIQUE,
+                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS password_reset_tokens (
+                id VARCHAR(36) PRIMARY KEY,
+                user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                token VARCHAR(64) NOT NULL UNIQUE,
+                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS energy_providers (
+                id VARCHAR(36) PRIMARY KEY,
+                name VARCHAR(255) NOT NULL UNIQUE,
+                logo_url VARCHAR(512),
+                website VARCHAR(512),
+                scraper_urls JSONB,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS energy_offers (
+                id VARCHAR(36) PRIMARY KEY,
+                provider_id VARCHAR(36) NOT NULL REFERENCES energy_providers(id) ON DELETE CASCADE,
+                name VARCHAR(255) NOT NULL,
+                offer_type VARCHAR(50) NOT NULL,
+                description TEXT,
+                subscription_price NUMERIC(10, 5) NOT NULL,
+                base_price NUMERIC(10, 5),
+                hc_price NUMERIC(10, 5),
+                hp_price NUMERIC(10, 5),
+                base_price_weekend NUMERIC(10, 5),
+                hp_price_weekend NUMERIC(10, 5),
+                hc_price_weekend NUMERIC(10, 5),
+                tempo_blue_hc NUMERIC(10, 5),
+                tempo_blue_hp NUMERIC(10, 5),
+                tempo_white_hc NUMERIC(10, 5),
+                tempo_white_hp NUMERIC(10, 5),
+                tempo_red_hc NUMERIC(10, 5),
+                tempo_red_hp NUMERIC(10, 5),
+                ejp_normal NUMERIC(10, 5),
+                ejp_peak NUMERIC(10, 5),
+                hc_price_winter NUMERIC(10, 5),
+                hp_price_winter NUMERIC(10, 5),
+                hc_price_summer NUMERIC(10, 5),
+                hp_price_summer NUMERIC(10, 5),
+                peak_day_price NUMERIC(10, 5),
+                hc_schedules JSONB,
+                power_kva INTEGER,
+                price_updated_at TIMESTAMP WITH TIME ZONE,
+                valid_from TIMESTAMP WITH TIME ZONE,
+                valid_to TIMESTAMP WITH TIME ZONE,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS offer_contributions (
+                id VARCHAR(36) PRIMARY KEY,
+                contributor_user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                contribution_type VARCHAR(50) NOT NULL,
+                status VARCHAR(50) NOT NULL DEFAULT 'pending',
+                provider_name VARCHAR(255),
+                provider_website VARCHAR(512),
+                existing_provider_id VARCHAR(36) REFERENCES energy_providers(id) ON DELETE SET NULL,
+                existing_offer_id VARCHAR(36) REFERENCES energy_offers(id) ON DELETE SET NULL,
+                offer_name VARCHAR(255) NOT NULL,
+                offer_type VARCHAR(50) NOT NULL,
+                description TEXT,
+                pricing_data JSONB NOT NULL,
+                hc_schedules JSONB,
+                power_kva INTEGER,
+                price_sheet_url VARCHAR(1024) NOT NULL,
+                screenshot_url VARCHAR(1024),
+                reviewed_by VARCHAR(36) REFERENCES users(id) ON DELETE SET NULL,
+                reviewed_at TIMESTAMP WITH TIME ZONE,
+                review_comment TEXT,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS tempo_days (
+                id VARCHAR PRIMARY KEY,
+                date TIMESTAMP WITH TIME ZONE NOT NULL UNIQUE,
+                color VARCHAR(10) NOT NULL,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                rte_updated_date TIMESTAMP WITH TIME ZONE
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS ecowatt (
+                id SERIAL PRIMARY KEY,
+                generation_datetime TIMESTAMP NOT NULL,
+                periode TIMESTAMP NOT NULL,
+                hdebut INTEGER NOT NULL,
+                hfin INTEGER NOT NULL,
+                pas INTEGER DEFAULT 60,
+                dvalue INTEGER NOT NULL,
+                message VARCHAR,
+                "values" JSONB NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                CONSTRAINT unique_ecowatt_periode UNIQUE (periode)
+            )
+        """)
+
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS refresh_tracker (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                cache_type VARCHAR NOT NULL UNIQUE,
+                last_refresh TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+            )
+        """)
+
+        # Create indexes if they don't exist
+        op.execute("CREATE INDEX IF NOT EXISTS ix_users_email ON users(email)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_users_client_id ON users(client_id)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_users_enedis_customer_id ON users(enedis_customer_id)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_pdls_usage_point_id ON pdls(usage_point_id)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_tokens_usage_point_id ON tokens(usage_point_id)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_roles_name ON roles(name)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_permissions_name ON permissions(name)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_email_verification_tokens_token ON email_verification_tokens(token)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_password_reset_tokens_token ON password_reset_tokens(token)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_tempo_days_date ON tempo_days(date)")
+        op.execute("CREATE INDEX IF NOT EXISTS idx_ecowatt_periode ON ecowatt(periode)")
+        op.execute("CREATE INDEX IF NOT EXISTS ix_refresh_tracker_cache_type ON refresh_tracker(cache_type)")
+
+    else:
+        # SQLite - tables are created via Base.metadata.create_all
+        # This is kept for reference
+        pass
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("DROP TABLE IF EXISTS refresh_tracker CASCADE")
+        op.execute("DROP TABLE IF EXISTS ecowatt CASCADE")
+        op.execute("DROP TABLE IF EXISTS tempo_days CASCADE")
+        op.execute("DROP TABLE IF EXISTS offer_contributions CASCADE")
+        op.execute("DROP TABLE IF EXISTS energy_offers CASCADE")
+        op.execute("DROP TABLE IF EXISTS energy_providers CASCADE")
+        op.execute("DROP TABLE IF EXISTS password_reset_tokens CASCADE")
+        op.execute("DROP TABLE IF EXISTS email_verification_tokens CASCADE")
+        op.execute("DROP TABLE IF EXISTS tokens CASCADE")
+        op.execute("DROP TABLE IF EXISTS pdls CASCADE")
+        op.execute("DROP TABLE IF EXISTS users CASCADE")
+        op.execute("DROP TABLE IF EXISTS role_permissions CASCADE")
+        op.execute("DROP TABLE IF EXISTS permissions CASCADE")
+        op.execute("DROP TABLE IF EXISTS roles CASCADE")

--- a/apps/api/alembic/versions/20251201_0200_002_add_pricing_option_to_pdls.py
+++ b/apps/api/alembic/versions/20251201_0200_002_add_pricing_option_to_pdls.py
@@ -1,0 +1,57 @@
+"""Add pricing_option to pdls table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-12-01 02:00:00
+
+Adds the pricing_option column to the pdls table if it doesn't exist.
+This column stores the tariff type: BASE, HC_HP, TEMPO, EJP, HC_WEEKEND.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        # PostgreSQL - use IF NOT EXISTS pattern via DO block
+        op.execute("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'pdls' AND column_name = 'pricing_option'
+                ) THEN
+                    ALTER TABLE pdls ADD COLUMN pricing_option VARCHAR(50);
+                END IF;
+            END $$;
+        """)
+    else:
+        # SQLite - no IF NOT EXISTS for ALTER TABLE, need to check first
+        try:
+            op.add_column("pdls", sa.Column("pricing_option", sa.String(50), nullable=True))
+        except Exception:
+            # Column already exists
+            pass
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("ALTER TABLE pdls DROP COLUMN IF EXISTS pricing_option")
+    else:
+        # SQLite doesn't support DROP COLUMN easily, leave it
+        pass

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Starting MyElectricalData API..."
+
+# Run database migrations
+echo "Applying database migrations..."
+alembic upgrade head
+echo "Migrations applied successfully"
+
+# Start the application
+echo "Starting uvicorn server..."
+exec uvicorn src.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- Set up Alembic configuration with async support for both PostgreSQL and SQLite
- Create baseline and pricing_option column migrations
- Implement automatic migrations on container startup
- Add comprehensive migration management commands via Makefile
- Fixes the missing pricing_option column error in PostgreSQL queries

## Test plan
- [ ] Run `make migrate` to apply migrations
- [ ] Verify `pricing_option` column exists on PDLs table
- [ ] Check `make migrate-history` shows both migrations
- [ ] Restart backend container and verify migrations auto-apply
- [ ] Test `make migrate-downgrade` for rollback functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)