### PR TITLE
feat: auto-seed default roles and permissions on startup

### DIFF
--- a/apps/api/src/models/database.py
+++ b/apps/api/src/models/database.py
@@ -15,5 +15,12 @@ async def get_db() -> AsyncSession:
 
 
 async def init_db() -> None:
+    """Initialize the database: create tables and seed default data."""
+    # Create all tables
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    # Seed default roles and permissions
+    from .seed import init_default_roles_and_permissions
+    async with async_session_maker() as session:
+        await init_default_roles_and_permissions(session)

--- a/apps/api/src/models/seed.py
+++ b/apps/api/src/models/seed.py
@@ -1,0 +1,187 @@
+"""
+Default roles and permissions seed data.
+
+This module provides functions to initialize default roles and permissions
+in the database when the application starts for the first time.
+"""
+
+import logging
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from .role import Role, Permission
+
+logger = logging.getLogger(__name__)
+
+
+# Default permissions grouped by resource
+DEFAULT_PERMISSIONS = [
+    # Admin Dashboard
+    {
+        "name": "admin_dashboard",
+        "display_name": "Tableau de bord admin",
+        "description": "Accès au tableau de bord d'administration",
+        "resource": "admin_dashboard",
+    },
+    # Users management
+    {
+        "name": "users",
+        "display_name": "Gestion des utilisateurs",
+        "description": "Voir la liste des utilisateurs",
+        "resource": "users",
+    },
+    {
+        "name": "users.edit",
+        "display_name": "Modifier les utilisateurs",
+        "description": "Créer, modifier et gérer les utilisateurs",
+        "resource": "users",
+    },
+    {
+        "name": "users.delete",
+        "display_name": "Supprimer les utilisateurs",
+        "description": "Supprimer des utilisateurs",
+        "resource": "users",
+    },
+    # Logs
+    {
+        "name": "logs",
+        "display_name": "Voir les logs",
+        "description": "Consulter les logs de l'application",
+        "resource": "logs",
+    },
+    {
+        "name": "logs.delete",
+        "display_name": "Supprimer les logs",
+        "description": "Supprimer les logs de l'application",
+        "resource": "logs",
+    },
+    # Contributions
+    {
+        "name": "contributions",
+        "display_name": "Gestion des contributions",
+        "description": "Modérer les contributions des utilisateurs",
+        "resource": "contributions",
+    },
+    # Energy Offers
+    {
+        "name": "offers",
+        "display_name": "Gestion des offres",
+        "description": "Gérer les offres tarifaires",
+        "resource": "offers",
+    },
+    {
+        "name": "offers.delete",
+        "display_name": "Supprimer les offres",
+        "description": "Supprimer des offres tarifaires",
+        "resource": "offers",
+    },
+    # Roles
+    {
+        "name": "roles",
+        "display_name": "Gestion des rôles",
+        "description": "Gérer les rôles et permissions",
+        "resource": "roles",
+    },
+]
+
+
+# Default roles with their permissions
+DEFAULT_ROLES = [
+    {
+        "name": "admin",
+        "display_name": "Administrateur",
+        "description": "Accès complet à toutes les fonctionnalités",
+        "is_system": True,
+        "permissions": [
+            "admin_dashboard",
+            "users",
+            "users.edit",
+            "users.delete",
+            "logs",
+            "logs.delete",
+            "contributions",
+            "offers",
+            "offers.delete",
+            "roles",
+        ],
+    },
+    {
+        "name": "moderator",
+        "display_name": "Modérateur",
+        "description": "Modération des contributions et gestion limitée",
+        "is_system": True,
+        "permissions": [
+            "admin_dashboard",
+            "users",
+            "contributions",
+            "offers",
+            "logs",
+        ],
+    },
+    {
+        "name": "visitor",
+        "display_name": "Visiteur",
+        "description": "Accès en lecture seule aux données publiques",
+        "is_system": True,
+        "permissions": [],
+    },
+]
+
+
+async def init_default_roles_and_permissions(db: AsyncSession) -> None:
+    """
+    Initialize default roles and permissions in the database.
+
+    This function is idempotent - it only creates entries that don't exist yet.
+    It will not modify existing roles or permissions.
+    """
+    try:
+        # Check if permissions already exist
+        result = await db.execute(select(Permission).limit(1))
+        existing_permissions = result.scalar_one_or_none()
+
+        if existing_permissions:
+            logger.info("[SEED] Permissions already exist, skipping seed")
+            return
+
+        logger.info("[SEED] Initializing default permissions and roles...")
+
+        # Create permissions
+        permission_objects = {}
+        for perm_data in DEFAULT_PERMISSIONS:
+            permission = Permission(
+                name=perm_data["name"],
+                display_name=perm_data["display_name"],
+                description=perm_data["description"],
+                resource=perm_data["resource"],
+            )
+            db.add(permission)
+            permission_objects[perm_data["name"]] = permission
+            logger.info(f"[SEED] Created permission: {perm_data['name']}")
+
+        # Flush to get permission IDs
+        await db.flush()
+
+        # Create roles with their permissions
+        for role_data in DEFAULT_ROLES:
+            role = Role(
+                name=role_data["name"],
+                display_name=role_data["display_name"],
+                description=role_data["description"],
+                is_system=role_data["is_system"],
+            )
+
+            # Assign permissions to role
+            for perm_name in role_data["permissions"]:
+                if perm_name in permission_objects:
+                    role.permissions.append(permission_objects[perm_name])
+
+            db.add(role)
+            logger.info(f"[SEED] Created role: {role_data['name']} with {len(role_data['permissions'])} permissions")
+
+        await db.commit()
+        logger.info("[SEED] Default roles and permissions initialized successfully")
+
+    except Exception as e:
+        logger.error(f"[SEED] Error initializing roles and permissions: {e}")
+        await db.rollback()
+        raise


### PR DESCRIPTION
## Summary
- Add automatic seeding of default roles (admin, moderator, visitor) and 10 permissions to the database
- Initialize seed data when app starts via `init_db()` if database is empty
- Seed is idempotent - only runs once and does not modify existing data

## Test Plan
- [ ] Start fresh database and verify roles appear in admin panel
- [ ] Deploy to new server and confirm roles are auto-created
- [ ] Verify existing databases are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)