### PR TITLE
feat: sync ADMIN_EMAILS users with admin role on startup

### DIFF
--- a/apps/api/src/models/database.py
+++ b/apps/api/src/models/database.py
@@ -21,6 +21,10 @@ async def init_db() -> None:
         await conn.run_sync(Base.metadata.create_all)
 
     # Seed default roles and permissions
-    from .seed import init_default_roles_and_permissions
+    from .seed import init_default_roles_and_permissions, sync_admin_users
     async with async_session_maker() as session:
         await init_default_roles_and_permissions(session)
+
+    # Ensure ADMIN_EMAILS users have admin role (runs every startup)
+    async with async_session_maker() as session:
+        await sync_admin_users(session)


### PR DESCRIPTION
## Summary
- Add sync_admin_users() function to ensure all users in ADMIN_EMAILS always have the admin role at startup
- Runs after seed to verify and correct admin roles, even if accidentally changed
- Prevents loss of admin access when ADMIN_EMAILS is configured

## Test Plan
- [ ] Verify admin users sync on application startup
- [ ] Confirm users in ADMIN_EMAILS get admin role restored if changed
- [ ] Test with no ADMIN_EMAILS configured (should skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)