### PR TITLE
debug: Add console logs to Contribute page providers

### DIFF
--- a/apps/web/src/pages/Contribute.tsx
+++ b/apps/web/src/pages/Contribute.tsx
@@ -13,16 +13,20 @@ export default function Contribute() {
   const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({})
 
   // Fetch providers
-  const { data: providersData } = useQuery({
+  const { data: providersData, isLoading: isLoadingProviders, error: providersError } = useQuery({
     queryKey: ['energy-providers'],
     queryFn: async () => {
       const response = await energyApi.getProviders()
+      console.log('[Contribute] Providers API response:', response)
       if (response.success && Array.isArray(response.data)) {
         return response.data as EnergyProvider[]
       }
       return []
     },
   })
+
+  // Debug: Log providers state
+  console.log('[Contribute] providersData:', providersData, 'isLoading:', isLoadingProviders, 'error:', providersError)
 
   // Fetch user's contributions
   const { data: myContributions } = useQuery({


### PR DESCRIPTION
## Summary

Added console logging to debug why the providers list appears empty on the Contribute page. This will help identify if the issue is in the API response, data fetching, or rendering.

## Changes

- Added `console.log()` statements to track providers data state
- Log API response and component state variables
- Helps identify where the data flow breaks

## Test plan

- [ ] Navigate to /contribute page
- [ ] Open browser console (F12)
- [ ] Check console logs for provider data
- [ ] Verify `providersData`, `isLoading`, and `error` states

🤖 Generated with [Claude Code](https://claude.com/claude-code)