### PR TITLE
fix(admin): fix dashboard stats and add loading UI

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -11,7 +11,7 @@ from ..models import User, PDL, EnergyProvider, EnergyOffer
 from ..models.database import get_db
 from ..middleware import require_admin, require_permission, get_current_user
 from ..schemas import APIResponse
-from ..services import rate_limiter
+from ..services import rate_limiter, cache_service
 from ..services.price_update_service import PriceUpdateService
 from ..config import settings
 import redis.asyncio as redis

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2259,19 +2259,6 @@
         }
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      }
-    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-rc.4.tgz",
@@ -7893,19 +7880,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/tree-sitter-json": {

--- a/apps/web/src/components/LoadingOverlay.tsx
+++ b/apps/web/src/components/LoadingOverlay.tsx
@@ -7,7 +7,7 @@ interface LoadingOverlayProps {
   /** Sous-message optionnel (ex: "Veuillez patienter...") */
   subMessage?: string
   /** Type de données en cours de chargement pour adapter le message */
-  dataType?: 'consumption' | 'production' | 'simulation' | 'balance'
+  dataType?: 'consumption' | 'production' | 'simulation' | 'balance' | 'admin'
   /** Si true, joue l'animation de sortie (fade out) */
   isExiting?: boolean
   /** Contenu à afficher en arrière-plan (sera flouté) */
@@ -41,6 +41,10 @@ export function LoadingOverlay({
     balance: {
       message: 'Chargement du bilan énergétique',
       subMessage: 'Récupération depuis le cache...'
+    },
+    admin: {
+      message: 'Chargement des statistiques',
+      subMessage: 'Récupération des données de la plateforme...'
     }
   }
 

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { adminApi } from '@/api/admin'
 import { Users, Activity, CheckCircle, XCircle, ChevronDown, ChevronUp, ArrowUpDown, ArrowUp, ArrowDown, Trash2, AlertTriangle } from 'lucide-react'
+import { LoadingOverlay } from '@/components/LoadingOverlay'
 
 type SortField = 'total' | 'cached' | 'no_cache'
 type SortDirection = 'asc' | 'desc'
@@ -31,7 +32,7 @@ export default function Admin() {
     return sortDirection === 'desc' ? <ArrowDown size={14} /> : <ArrowUp size={14} />
   }
 
-  const { data: statsResponse } = useQuery({
+  const { data: statsResponse, isLoading, isError } = useQuery({
     queryKey: ['admin-stats'],
     queryFn: () => adminApi.getGlobalStats(),
     refetchInterval: 30000,
@@ -125,6 +126,26 @@ export default function Admin() {
               >
                 {clearAllCacheMutation.isPending ? 'Vidage...' : 'Vider le cache'}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && (
+        <LoadingOverlay dataType="admin" />
+      )}
+
+      {/* Error State */}
+      {isError && !isLoading && (
+        <div className="card border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20">
+          <div className="flex items-center gap-3">
+            <XCircle className="text-red-600 dark:text-red-400" size={24} />
+            <div>
+              <h3 className="font-semibold text-red-900 dark:text-red-200">Erreur de chargement</h3>
+              <p className="text-sm text-red-700 dark:text-red-300">
+                Impossible de charger les statistiques. Vérifiez que le backend est accessible.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Fixed missing `cache_service` import in admin router that caused NameError when loading statistics. Added professional loading overlay with blur effect matching the design of other pages.

## Changes
- Fixed backend endpoint by importing `cache_service` in `apps/api/src/routers/admin.py`
- Added loading state using `LoadingOverlay` component with blur effect in Admin dashboard
- Extended `LoadingOverlay` to support 'admin' data type with appropriate messages

## Testing
The admin dashboard now displays a proper loading spinner while fetching statistics, and shows all stats correctly after the API call completes.