### PR TITLE
ci: cancel in-progress builds on new commits to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,10 +18,10 @@ permissions:
   pages: write
   id-token: write
 
-# Un seul déploiement à la fois
+# Un seul déploiement à la fois - annule les builds en cours
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ''
 
+# Annule les builds en cours sur la même branche
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/myelectricaldata/myelectricaldata_new

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
 
+# Annule les builds en cours sur la même branche
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   CHART_PATH: helm/myelectricaldata


### PR DESCRIPTION
## Summary
- Adds concurrency configuration with `cancel-in-progress: true` to all GitHub Actions workflows
- Ensures only the latest commit build runs on main, automatically cancelling builds already in progress
- Updated `deploy-docs.yml` to use dynamic group instead of static "pages" group

## Test plan
- Trigger multiple workflows in quick succession on main
- Verify that earlier builds are automatically cancelled
- Confirm the latest commit build completes normally

🤖 Generated with Claude Code