### PR TITLE
fix(web): move @headlessui/react to react-vendor chunk

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2011,6 +2011,19 @@
         }
       }
     },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0.tgz",
@@ -7752,6 +7765,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/tree-sitter-json": {


### PR DESCRIPTION
## Summary
Fixes production error: "Cannot read properties of undefined (reading 'forwardRef')"

@headlessui/react depends on React.forwardRef but was bundled in a separate chunk that could load before React in production.

## Solution
Move @headlessui/react to the same chunk as React to ensure proper load order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)