### PR TITLE
fix(web): use object-based manualChunks to prevent circular deps

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,37 +30,24 @@ export default defineConfig(({ mode }) => {
           entryFileNames: 'assets/[name]-[hash].js',
           chunkFileNames: 'assets/[name]-[hash].js',
           assetFileNames: 'assets/[name]-[hash].[ext]',
-          manualChunks(id) {
-            // Core React + React-dependent UI libs - must stay together
-            // @headlessui/react uses React.forwardRef, so it must be in the same chunk
-            if (id.includes('node_modules/react/') ||
-                id.includes('node_modules/react-dom/') ||
-                id.includes('node_modules/react-router-dom/') ||
-                id.includes('@headlessui/react')) {
-              return 'react-vendor';
-            }
-            // UI utilities - no React dependency
-            if (id.includes('lucide-react') ||
-                id.includes('clsx')) {
-              return 'ui-vendor';
-            }
-            // Charts - only on dashboard/consumption pages
-            if (id.includes('recharts')) {
-              return 'chart-vendor';
-            }
-            // Data fetching - loaded on most pages
-            if (id.includes('@tanstack/react-query') ||
-                id.includes('axios') ||
-                id.includes('zustand')) {
-              return 'query-vendor';
-            }
-            // Heavy dependencies - lazy loaded
-            if (id.includes('swagger-ui-react')) {
-              return 'swagger-ui';
-            }
-            if (id.includes('jspdf') || id.includes('html2canvas')) {
-              return 'pdf-vendor';
-            }
+          manualChunks: {
+            // Core vendor - all node_modules except heavy lazy-loaded ones
+            // Using object syntax prevents circular dependency issues
+            vendor: [
+              'react',
+              'react-dom',
+              'react-router-dom',
+              '@headlessui/react',
+              '@tanstack/react-query',
+              'axios',
+              'zustand',
+              'lucide-react',
+              'clsx',
+            ],
+            // Charts - lazy loaded on dashboard/consumption pages
+            charts: ['recharts'],
+            // PDF generation - lazy loaded
+            pdf: ['jspdf', 'html2canvas'],
           },
         },
       },


### PR DESCRIPTION
## Summary
Fixes production error: "Cannot read properties of undefined (reading 'forwardRef')"

The previous fix (#65) only moved @headlessui/react but didn't solve the root cause: circular dependencies between chunks (`react-vendor` → `chart-vendor` → `react-vendor`).

## Solution
Switch from function-based to object-based `manualChunks` syntax, consolidating all core dependencies into a single `vendor` chunk. This eliminates circular dependencies.

## Changes
- `react-vendor`, `ui-vendor`, `query-vendor` → single `vendor` chunk
- `chart-vendor` → `charts` chunk (lazy loaded)
- `pdf-vendor` → `pdf` chunk (lazy loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)