### PR TITLE
fix(web): display selected provider on initial load

### DIFF
--- a/apps/web/src/components/OfferSelector.tsx
+++ b/apps/web/src/components/OfferSelector.tsx
@@ -95,13 +95,32 @@ export default function OfferSelector({
     return allOffers.find(o => o.id === selectedOfferId) || null
   }, [selectedOfferId, allOffers])
 
-  // Initialize selectors from selected offer
+  // Initialize/sync selectors from selected offer
+  // This effect handles two cases:
+  // 1. Initial mount with a selectedOfferId - wait for offers to load then sync
+  // 2. selectedOfferId prop changes externally - sync to new offer
+  // We track which offer we've synced to avoid interfering with manual user selection
+  const [lastSyncedOfferId, setLastSyncedOfferId] = useState<string | null | undefined>(undefined)
+
   useEffect(() => {
     if (selectedOffer) {
-      setSelectedProviderId(selectedOffer.provider_id)
-      setSelectedOfferType(selectedOffer.offer_type)
+      // We have a valid offer - sync the selectors if not already synced to this offer
+      if (lastSyncedOfferId !== selectedOffer.id) {
+        setSelectedProviderId(selectedOffer.provider_id)
+        setSelectedOfferType(selectedOffer.offer_type)
+        setLastSyncedOfferId(selectedOffer.id)
+      }
+    } else if (selectedOfferId === null || selectedOfferId === undefined) {
+      // Offer was cleared externally - reset selectors
+      if (lastSyncedOfferId !== null) {
+        setSelectedProviderId(null)
+        setSelectedOfferType(null)
+        setLastSyncedOfferId(null)
+      }
     }
-  }, [selectedOffer])
+    // Note: when selectedOfferId is set but selectedOffer is null (offers loading),
+    // we wait - the effect will re-run when offers finish loading
+  }, [selectedOffer, selectedOfferId, lastSyncedOfferId])
 
   // Reset offer type when provider changes
   const handleProviderChange = (providerId: string | null) => {


### PR DESCRIPTION
## Summary
Fix issue where selected energy offer was not displayed on Dashboard page load. When navigating back to a PDL card with a pre-selected offer (cached by React Query), the cascading selectors showed 'Sélectionner...' instead of the saved values.

## Changes
- Add synced state tracking to OfferSelector to prevent selector resets during manual user selection
- Ensure cascading selectors initialize correctly when offers data is already cached
- Handle both initial mount and external offer changes

## Testing
- Verify selected offer displays correctly on Dashboard load
- Test manual selection still works properly
- Test offer clearing and re-selection flows