### PR TITLE
Hide linked production PDLs from selector

### DIFF
--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -112,6 +112,14 @@ export default function PageHeader() {
   // Check if on a consumption page
   const isConsumptionPage = location.pathname.startsWith('/consumption')
 
+  // Get the set of production PDL IDs that are linked to consumption PDLs
+  // These should be hidden from the selector (the consumption PDL will show instead)
+  const linkedProductionIds = new Set(
+    pdls
+      .filter((pdl: PDL) => pdl.has_consumption && pdl.linked_production_pdl_id)
+      .map((pdl: PDL) => pdl.linked_production_pdl_id)
+  )
+
   // Filter PDLs based on page
   const displayedPdls = location.pathname === '/production'
     ? (() => {
@@ -122,22 +130,16 @@ export default function PageHeader() {
           pdl.linked_production_pdl_id
         )
 
-        const linkedProductionIds = new Set(
-          pdls
-            .filter((pdl: PDL) => pdl.has_consumption && pdl.linked_production_pdl_id)
-            .map((pdl: PDL) => pdl.linked_production_pdl_id)
-        )
-
         const standaloneProduction = activePdls.filter((pdl: PDL) =>
           pdl.has_production &&
-          !linkedProductionIds.has(pdl.usage_point_id)
+          !linkedProductionIds.has(pdl.id) // Use pdl.id (UUID) not usage_point_id
         )
 
         return [...consumptionWithProduction, ...standaloneProduction]
       })()
     : isConsumptionPage
     ? activePdls.filter((pdl: PDL) => pdl.has_consumption)
-    : activePdls
+    : activePdls.filter((pdl: PDL) => !linkedProductionIds.has(pdl.id)) // Hide linked production PDLs globally
 
   return (
     <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- Fix bug where `linked_production_pdl_id` comparison uses UUID instead of `usage_point_id`
- Hide production PDLs that are linked to consumption PDLs from all page selectors
- Ensures only consumption PDLs appear when production is linked, following the requirement: "Si j'ai liée un pdl de production à un pdl de consommation, il faut que tu affiche uniquement le PDL de consommation et masque le pdl de production"

## Test plan
- [ ] Verify production PDL linked to consumption PDL is hidden in header selector
- [ ] Verify only consumption PDL is displayed when production is linked
- [ ] Test on /production, /consumption_kwh, /dashboard, and other pages with PDL selector