### PR TITLE
feat(conductor): add Docker Compose dev environment with dynamic ports

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,30 @@
+# Configuration locale pour l'infrastructure partagée
+# Copier ce fichier vers .env.local et ajuster selon votre environnement
+
+# =============================================================================
+# Redis - Cache partagé entre les branches
+# =============================================================================
+# Option 1: Redis local (Docker ou natif)
+REDIS_URL=redis://localhost:6379/0
+
+# Option 2: Redis Docker sur le réseau host
+# REDIS_URL=redis://host.docker.internal:6379/0
+
+# =============================================================================
+# PostgreSQL - Base de données partagée entre les branches
+# =============================================================================
+# Option 1: PostgreSQL local (Docker ou natif)
+DATABASE_URL=postgresql+asyncpg://myelectricaldata:mySecurePassword2025@localhost:5432/myelectricaldata
+
+# Option 2: PostgreSQL Docker sur le réseau host
+# DATABASE_URL=postgresql+asyncpg://myelectricaldata:mySecurePassword2025@host.docker.internal:5432/myelectricaldata
+
+# Option 3: SQLite (pas recommandé pour multi-branches)
+# DATABASE_URL=sqlite+aiosqlite:///./data/myelectricaldata.db
+
+# =============================================================================
+# Ports personnalisés (optionnel)
+# =============================================================================
+# Si vous voulez forcer des ports spécifiques au lieu de ports dynamiques
+# FRONTEND_PORT=8000
+# BACKEND_PORT=8081

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ Thumbs.db
 # Docker
 docker-compose.override.yml
 
+# Conductor
+.conductor-ports
+
 # Logs
 *.log
 logs/

--- a/conductor.json
+++ b/conductor.json
@@ -1,64 +1,78 @@
 {
-  "name": "k8s-auto-deploy-script",
-  "description": "Script de déploiement automatique K8s avec mode dev (volumes locaux)",
+  "name": "myelectricaldata-dev",
+  "description": "Environnement de développement Docker Compose avec ports dynamiques",
   "onStart": {
-    "command": "./scripts/k8s-deploy.sh deploy",
-    "description": "Déploie automatiquement sur K8s au démarrage du projet",
+    "command": "./scripts/conductor-start.sh",
+    "description": "Démarre les services frontend et backend avec ports libres",
     "waitForReady": true,
-    "timeout": 300
+    "timeout": 180
   },
   "onStop": {
-    "command": "./scripts/k8s-deploy.sh delete",
-    "description": "Supprime le déploiement K8s à l'arrêt du projet",
-    "confirm": true
+    "command": "./scripts/conductor-stop.sh",
+    "description": "Arrête les services Docker Compose"
+  },
+  "services": {
+    "frontend": {
+      "type": "docker-compose",
+      "service": "frontend",
+      "portVariable": "FRONTEND_PORT",
+      "defaultPort": 8000,
+      "healthCheck": "http://localhost:${FRONTEND_PORT}"
+    },
+    "backend": {
+      "type": "docker-compose",
+      "service": "backend",
+      "portVariable": "BACKEND_PORT",
+      "defaultPort": 8081,
+      "healthCheck": "http://localhost:${BACKEND_PORT}/ping"
+    }
+  },
+  "infrastructure": {
+    "redis": {
+      "type": "external",
+      "envFile": ".env.local",
+      "envVariable": "REDIS_URL",
+      "default": "redis://localhost:6379/0"
+    },
+    "postgres": {
+      "type": "external",
+      "envFile": ".env.local",
+      "envVariable": "DATABASE_URL",
+      "default": "postgresql+asyncpg://myelectricaldata:mySecurePassword2025@localhost:5432/myelectricaldata"
+    }
   },
   "scripts": {
-    "k8s:deploy": {
-      "command": "./scripts/k8s-deploy.sh deploy",
-      "description": "Déploie l'application en mode dev sur K8s (rancher-desktop)"
+    "start": {
+      "command": "./scripts/conductor-start.sh",
+      "description": "Démarre les services frontend et backend"
     },
-    "k8s:deploy:prod": {
-      "command": "./scripts/k8s-deploy.sh --prod deploy",
-      "description": "Déploie l'application en mode production sur K8s"
+    "stop": {
+      "command": "./scripts/conductor-stop.sh",
+      "description": "Arrête les services Docker Compose"
     },
-    "k8s:delete": {
-      "command": "./scripts/k8s-deploy.sh delete",
-      "description": "Supprime le déploiement K8s"
+    "logs": {
+      "command": "docker compose logs -f frontend backend",
+      "description": "Affiche les logs des services"
     },
-    "k8s:status": {
-      "command": "./scripts/k8s-deploy.sh status",
-      "description": "Affiche le statut du déploiement K8s"
-    },
-    "k8s:logs:backend": {
-      "command": "./scripts/k8s-deploy.sh logs backend",
+    "logs:backend": {
+      "command": "docker compose logs -f backend",
       "description": "Affiche les logs du backend"
     },
-    "k8s:logs:frontend": {
-      "command": "./scripts/k8s-deploy.sh logs frontend",
+    "logs:frontend": {
+      "command": "docker compose logs -f frontend",
       "description": "Affiche les logs du frontend"
+    },
+    "restart": {
+      "command": "docker compose restart frontend backend",
+      "description": "Redémarre les services"
+    },
+    "status": {
+      "command": "docker compose ps",
+      "description": "Affiche le statut des services"
     }
   },
-  "kubernetes": {
-    "context": "rancher-desktop",
-    "namespace": "auto",
-    "devMode": {
-      "enabled": true,
-      "hostPath": "/Users/cvalentin/Git/myelectricaldata_new",
-      "mounts": {
-        "backend": {
-          "src": "apps/api/src",
-          "static": "apps/api/static"
-        },
-        "frontend": {
-          "src": "apps/web/src",
-          "public": "apps/web/public"
-        }
-      }
-    },
-    "helm": {
-      "chart": "helm/myelectricaldata",
-      "valuesFile": "helm/values-dev.yaml",
-      "releasePrefix": "med"
-    }
+  "env": {
+    "COMPOSE_PROJECT_NAME": "med-${CONDUCTOR_BRANCH_SLUG}",
+    "CONDUCTOR_BRANCH_SLUG": "${CONDUCTOR_BRANCH_SLUG:-dev}"
   }
 }

--- a/scripts/conductor-start.sh
+++ b/scripts/conductor-start.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Script de démarrage Conductor pour MyElectricalData
+# Démarre les services frontend et backend avec des ports dynamiques
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Couleurs pour les logs
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Fonction pour trouver un port libre
+find_free_port() {
+    local start_port=$1
+    local port=$start_port
+    while lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; do
+        port=$((port + 1))
+        if [ $port -gt $((start_port + 100)) ]; then
+            log_error "Impossible de trouver un port libre à partir de $start_port"
+            exit 1
+        fi
+    done
+    echo $port
+}
+
+# Charger la configuration locale si elle existe
+if [ -f ".env.local" ]; then
+    log_info "Chargement de .env.local..."
+    export $(grep -v '^#' .env.local | xargs)
+fi
+
+# Définir le nom du projet unique pour cette branche
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "dev")
+BRANCH_SLUG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+export COMPOSE_PROJECT_NAME="med-${BRANCH_SLUG}"
+
+log_info "Branche: $BRANCH_NAME"
+log_info "Projet Docker: $COMPOSE_PROJECT_NAME"
+
+# Déterminer les ports à utiliser
+if [ -z "$FRONTEND_PORT" ]; then
+    FRONTEND_PORT=$(find_free_port 8000)
+fi
+if [ -z "$BACKEND_PORT" ]; then
+    BACKEND_PORT=$(find_free_port 8081)
+fi
+
+export FRONTEND_PORT
+export BACKEND_PORT
+
+log_info "Port Frontend: $FRONTEND_PORT"
+log_info "Port Backend: $BACKEND_PORT"
+
+# Vérifier la configuration Redis/PostgreSQL
+REDIS_URL="${REDIS_URL:-redis://localhost:6379/0}"
+DATABASE_URL="${DATABASE_URL:-sqlite+aiosqlite:///./data/myelectricaldata.db}"
+
+log_info "Redis: $REDIS_URL"
+log_info "Database: $(echo $DATABASE_URL | sed 's/:.*@/:***@/')"
+
+# Créer le fichier .env.api à partir du template si nécessaire
+if [ ! -f ".env.api" ]; then
+    if [ -f "apps/api/.env.example" ]; then
+        log_info "Création de .env.api à partir du template..."
+        cp apps/api/.env.example .env.api
+    fi
+fi
+
+# Mettre à jour les URLs dans .env.api
+if [ -f ".env.api" ]; then
+    # Mettre à jour REDIS_URL
+    if grep -q "^REDIS_URL=" .env.api; then
+        sed -i.bak "s|^REDIS_URL=.*|REDIS_URL=$REDIS_URL|" .env.api
+    else
+        echo "REDIS_URL=$REDIS_URL" >> .env.api
+    fi
+
+    # Mettre à jour DATABASE_URL
+    if grep -q "^DATABASE_URL=" .env.api; then
+        sed -i.bak "s|^DATABASE_URL=.*|DATABASE_URL=$DATABASE_URL|" .env.api
+    else
+        echo "DATABASE_URL=$DATABASE_URL" >> .env.api
+    fi
+
+    # Mettre à jour FRONTEND_URL et BACKEND_URL pour le dev
+    sed -i.bak "s|^FRONTEND_URL=.*|FRONTEND_URL=http://localhost:$FRONTEND_PORT|" .env.api
+    sed -i.bak "s|^BACKEND_URL=.*|BACKEND_URL=http://localhost:$BACKEND_PORT|" .env.api
+
+    rm -f .env.api.bak
+fi
+
+# Créer le fichier .env pour le frontend
+cat > apps/web/.env <<EOF
+VITE_API_BASE_URL=http://localhost:$BACKEND_PORT
+VITE_APP_NAME=MyElectricalData
+EOF
+
+# Générer le docker-compose.override.yml avec les ports dynamiques
+cat > docker-compose.override.yml <<EOF
+# Fichier généré automatiquement par conductor-start.sh
+# Ne pas éditer manuellement - les modifications seront écrasées
+
+services:
+  backend:
+    ports:
+      - "${BACKEND_PORT}:8000"
+    environment:
+      - REDIS_URL=${REDIS_URL}
+      - DATABASE_URL=${DATABASE_URL}
+      - FRONTEND_URL=http://localhost:${FRONTEND_PORT}
+      - BACKEND_URL=http://localhost:${BACKEND_PORT}
+
+  frontend:
+    ports:
+      - "${FRONTEND_PORT}:5173"
+    environment:
+      - VITE_API_BASE_URL=http://localhost:${BACKEND_PORT}
+EOF
+
+# Sauvegarder les ports utilisés pour le script stop
+cat > .conductor-ports <<EOF
+FRONTEND_PORT=$FRONTEND_PORT
+BACKEND_PORT=$BACKEND_PORT
+COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
+EOF
+
+log_info "Démarrage des services..."
+
+# Démarrer uniquement frontend et backend (sans redis, postgres, pgadmin, docs)
+docker compose up -d --build frontend backend
+
+# Attendre que les services soient prêts
+log_info "Attente du démarrage des services..."
+
+# Attendre le backend
+MAX_WAIT=60
+WAIT=0
+while [ $WAIT -lt $MAX_WAIT ]; do
+    if curl -s "http://localhost:$BACKEND_PORT/ping" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+    WAIT=$((WAIT + 1))
+done
+
+if [ $WAIT -ge $MAX_WAIT ]; then
+    log_warn "Le backend n'a pas démarré dans les temps (timeout: ${MAX_WAIT}s)"
+else
+    log_success "Backend prêt!"
+fi
+
+# Attendre le frontend
+WAIT=0
+while [ $WAIT -lt $MAX_WAIT ]; do
+    if curl -s "http://localhost:$FRONTEND_PORT" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+    WAIT=$((WAIT + 1))
+done
+
+if [ $WAIT -ge $MAX_WAIT ]; then
+    log_warn "Le frontend n'a pas démarré dans les temps (timeout: ${MAX_WAIT}s)"
+else
+    log_success "Frontend prêt!"
+fi
+
+echo ""
+log_success "======================================"
+log_success "Services démarrés avec succès!"
+log_success "======================================"
+echo ""
+echo -e "  ${GREEN}Frontend:${NC}  http://localhost:$FRONTEND_PORT"
+echo -e "  ${GREEN}Backend:${NC}   http://localhost:$BACKEND_PORT"
+echo -e "  ${GREEN}API Docs:${NC}  http://localhost:$BACKEND_PORT/docs"
+echo ""

--- a/scripts/conductor-stop.sh
+++ b/scripts/conductor-stop.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Script d'arrêt Conductor pour MyElectricalData
+# Arrête les services frontend et backend
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Couleurs pour les logs
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Charger la configuration des ports si elle existe
+if [ -f ".conductor-ports" ]; then
+    source .conductor-ports
+    log_info "Configuration chargée: $COMPOSE_PROJECT_NAME"
+else
+    # Fallback: déterminer le nom du projet à partir de la branche
+    BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "dev")
+    BRANCH_SLUG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+    export COMPOSE_PROJECT_NAME="med-${BRANCH_SLUG}"
+fi
+
+log_info "Arrêt des services pour: $COMPOSE_PROJECT_NAME"
+
+# Arrêter les conteneurs
+docker compose down
+
+# Nettoyer les fichiers temporaires
+rm -f .conductor-ports
+rm -f docker-compose.override.yml
+
+log_success "Services arrêtés avec succès!"


### PR DESCRIPTION
## Summary

Replaces K8s deployment with lightweight Docker Compose setup for local development. Services start on automatically-detected free ports and share Redis/PostgreSQL infrastructure configured via `.env.local`.

## Changes

- **conductor.json**: Service configuration with health checks and dynamic port support
- **scripts/conductor-start.sh**: Auto-find free ports, generate docker-compose.override.yml, configure environment
- **scripts/conductor-stop.sh**: Clean shutdown and file cleanup
- **.env.local.example**: Template for Redis/PostgreSQL configuration
- **.gitignore**: Track generated files like .conductor-ports

## Usage

1. Copy `.env.local.example` to `.env.local` and configure Redis/PostgreSQL
2. Create new branch via Conductor - services auto-start on free ports
3. Each branch runs independently without port conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)