### PR TITLE
fix(conductor): support multi-instance deployment

### DIFF
--- a/docker-compose.conductor.yml
+++ b/docker-compose.conductor.yml
@@ -1,0 +1,56 @@
+# Docker Compose pour Conductor (multi-instances)
+# Utilise Redis et PostgreSQL externes configurés via .env.local
+# Les ports sont définis dynamiquement dans docker-compose.override.yml
+
+services:
+
+  # Backend FastAPI
+  backend:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ./.env.api
+    environment:
+      - PYTHONUNBUFFERED=1
+      - WATCHFILES_FORCE_POLLING=true
+      - WATCHFILES_POLL_INTERVAL=1000
+      - TZ=Europe/Paris
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./apps/api/data:/app/data
+      - ./apps/api/src:/app/src
+      - ./apps/api/static:/app/static
+      - backend_logs:/logs
+    command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "/app/src"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Frontend React/Vite
+  frontend:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile.dev
+    restart: unless-stopped
+    volumes:
+      - ./apps/web/src:/app/src
+      - ./apps/web/public:/app/public
+      - ./apps/web/index.html:/app/index.html
+      - ./apps/web/vite.config.ts:/app/vite.config.ts
+      - ./apps/web/tsconfig.json:/app/tsconfig.json
+      - ./apps/web/tsconfig.node.json:/app/tsconfig.node.json
+      - ./apps/web/tailwind.config.js:/app/tailwind.config.js
+      - ./apps/web/postcss.config.js:/app/postcss.config.js
+      - /app/node_modules
+    depends_on:
+      - backend
+
+volumes:
+  backend_logs:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   # Redis
   redis:
     image: redis:7-alpine
-    container_name: myelectricaldata-redis
     restart: unless-stopped
     command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
     volumes:
@@ -16,13 +15,10 @@ services:
       timeout: 5s
       retries: 3
 
-  # PostgreSQL (optionnel, activable via DATABASE_TYPE=postgresql)
+  # PostgreSQL
   postgres:
     image: postgres:16-alpine
-    container_name: myelectricaldata-postgres
     restart: unless-stopped
-    env_file :
-      - ./.env.api
     environment:
       POSTGRES_DB: myelectricaldata
       POSTGRES_USER: myelectricaldata
@@ -40,7 +36,6 @@ services:
   # pgAdmin - Interface web PostgreSQL
   pgadmin:
     image: dpage/pgadmin4:latest
-    container_name: myelectricaldata-pgadmin
     restart: unless-stopped
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@localhost.com
@@ -61,7 +56,6 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
-    container_name: myelectricaldata-backend
     restart: unless-stopped
     env_file:
       - ./.env.api
@@ -70,6 +64,8 @@ services:
       - WATCHFILES_FORCE_POLLING=true
       - WATCHFILES_POLL_INTERVAL=1000
       - TZ=Europe/Paris
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./apps/api/data:/app/data
       - ./apps/api/src:/app/src
@@ -80,8 +76,7 @@ services:
       - myelectricaldata
     depends_on:
       - redis
-    ports:
-      - "8081:8000"
+    # ports définis dans docker-compose.override.yml pour support multi-instances
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/ping')"]
       interval: 30s
@@ -94,7 +89,6 @@ services:
     build:
       context: ./apps/web
       dockerfile: Dockerfile.dev
-    container_name: myelectricaldata-frontend
     restart: unless-stopped
     volumes:
       - ./apps/web/src:/app/src
@@ -106,8 +100,7 @@ services:
       - ./apps/web/tailwind.config.js:/app/tailwind.config.js
       - ./apps/web/postcss.config.js:/app/postcss.config.js
       - /app/node_modules
-    ports:
-      - "8000:5173"
+    # ports définis dans docker-compose.override.yml pour support multi-instances
     networks:
       - myelectricaldata
     depends_on:
@@ -118,7 +111,6 @@ services:
     build:
       context: ./apps/docs
       dockerfile: Dockerfile
-    container_name: myelectricaldata-docs
     restart: unless-stopped
     volumes:
       - ./docs:/app/docs:ro
@@ -130,10 +122,6 @@ services:
       - docs
 
 volumes:
-  caddy_data:
-    driver: local
-  caddy_config:
-    driver: local
   redis_data:
     driver: local
   postgres_data:

--- a/scripts/conductor-stop.sh
+++ b/scripts/conductor-stop.sh
@@ -32,8 +32,8 @@ fi
 
 log_info "Arrêt des services pour: $COMPOSE_PROJECT_NAME"
 
-# Arrêter les conteneurs
-docker compose down
+# Arrêter les conteneurs (utiliser docker-compose.conductor.yml + override)
+docker compose -f docker-compose.conductor.yml -f docker-compose.override.yml down 2>/dev/null || docker compose -f docker-compose.conductor.yml down
 
 # Nettoyer les fichiers temporaires
 rm -f .conductor-ports


### PR DESCRIPTION
## Summary

- Create dedicated `docker-compose.conductor.yml` for Conductor with only frontend and backend
- Remove static `container_name` declarations to support concurrent instances on same host
- Move port definitions to `docker-compose.override.yml` for dynamic port allocation
- Configure external Redis/PostgreSQL access via `host.docker.internal` inside containers

## Test plan

- Run `./scripts/conductor-start.sh` - starts only frontend and backend (no Redis/PostgreSQL)
- Verify ports are dynamically allocated (8001, 8082, etc.)
- Run `./scripts/conductor-stop.sh` - cleanly stops services
- Multiple concurrent instances can run on different ports without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)