### PR TITLE
feat: make demo account read-only

### DIFF
--- a/apps/api/src/middleware/__init__.py
+++ b/apps/api/src/middleware/__init__.py
@@ -1,4 +1,12 @@
-from .auth import get_current_user
+from .auth import get_current_user, require_not_demo, is_demo_user, DEMO_EMAIL
 from .admin import require_admin, require_permission, require_action
 
-__all__ = ["get_current_user", "require_admin", "require_permission", "require_action"]
+__all__ = [
+    "get_current_user",
+    "require_admin",
+    "require_permission",
+    "require_action",
+    "require_not_demo",
+    "is_demo_user",
+    "DEMO_EMAIL",
+]

--- a/apps/api/src/middleware/auth.py
+++ b/apps/api/src/middleware/auth.py
@@ -15,6 +15,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Demo account email constant
+DEMO_EMAIL = "demo@myelectricaldata.fr"
+
 oauth2_scheme = OAuth2(
     flows=OAuthFlowsModel(
         clientCredentials={
@@ -133,3 +136,21 @@ async def get_current_user_optional(
         return user
 
     return None
+
+
+def is_demo_user(user: User) -> bool:
+    """Check if the user is a demo account"""
+    return user.email == DEMO_EMAIL
+
+
+async def require_not_demo(current_user: User = Depends(get_current_user)) -> User:
+    """
+    Middleware that blocks demo accounts from performing write operations.
+    Use this dependency on any endpoint that modifies data.
+    """
+    if is_demo_user(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Le compte de démonstration est en lecture seule"
+        )
+    return current_user

--- a/apps/api/src/routers/accounts.py
+++ b/apps/api/src/routers/accounts.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ..config import settings
-from ..middleware import get_current_user
+from ..middleware import get_current_user, require_not_demo
 from ..models import User, PDL, Token, EmailVerificationToken, PasswordResetToken, Role
 from ..models.database import get_db
 from ..schemas import (
@@ -314,7 +314,7 @@ async def get_credentials(current_user: User = Depends(get_current_user)) -> API
 
 @router.delete("/me", response_model=APIResponse)
 async def delete_account(
-    current_user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
+    current_user: User = Depends(require_not_demo), db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Delete user account and all associated data"""
     # Delete cache for all user's PDLs
@@ -436,7 +436,7 @@ async def resend_verification(
 
 @router.post("/regenerate-secret", response_model=APIResponse)
 async def regenerate_secret(
-    current_user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
+    current_user: User = Depends(require_not_demo), db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Regenerate client_secret and clear all cache"""
     # Generate new client_secret
@@ -589,7 +589,7 @@ async def reset_password(request: Request, db: AsyncSession = Depends(get_db)) -
 @router.post("/update-password", response_model=APIResponse)
 async def update_password(
     request: Request,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Update password for authenticated user (requires old password verification)"""

--- a/apps/api/src/routers/energy_offers.py
+++ b/apps/api/src/routers/energy_offers.py
@@ -5,7 +5,7 @@ from datetime import datetime, UTC
 from ..models import User, EnergyProvider, EnergyOffer, OfferContribution, ContributionMessage
 from ..models.database import get_db
 from ..schemas import APIResponse, ErrorDetail
-from ..middleware import get_current_user, require_permission, require_action
+from ..middleware import get_current_user, require_permission, require_action, require_not_demo
 from ..services.email import email_service
 from ..config import settings
 import logging
@@ -112,7 +112,7 @@ async def list_offers(
 # Contribution endpoints
 @router.post("/contribute", response_model=APIResponse, status_code=status.HTTP_201_CREATED)
 async def create_contribution(
-    contribution_data: dict, current_user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
+    contribution_data: dict, current_user: User = Depends(require_not_demo), db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Submit a new contribution for review"""
     logger.info(f"[CONTRIBUTION] New contribution from user: {current_user.email}")
@@ -168,7 +168,7 @@ async def create_contribution(
 async def update_contribution(
     contribution_id: str = Path(..., description="Contribution ID"),
     contribution_data: dict = Body(...),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Update an existing contribution (only pending or rejected ones owned by the user)"""
@@ -303,7 +303,7 @@ async def list_my_contributions(current_user: User = Depends(get_current_user), 
 async def reply_to_contribution(
     contribution_id: str,
     body: dict = Body(...),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Allow contributor to reply to admin messages on their own contribution"""

--- a/apps/api/src/routers/pdl.py
+++ b/apps/api/src/routers/pdl.py
@@ -7,7 +7,7 @@ from ..models.energy_provider import EnergyOffer
 from ..models.database import get_db
 from ..schemas import PDLCreate, PDLResponse, APIResponse, ErrorDetail
 from ..schemas.requests import AdminPDLCreate
-from ..middleware import get_current_user, require_admin, require_permission
+from ..middleware import get_current_user, require_admin, require_permission, require_not_demo
 from ..routers.enedis import get_valid_token
 from ..adapters import enedis_adapter
 import logging
@@ -129,7 +129,7 @@ async def create_pdl(
             }
         }
     ),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Add a new PDL to current user"""
@@ -364,7 +364,7 @@ async def get_pdl(
 @router.delete("/{pdl_id}", response_model=APIResponse)
 async def delete_pdl(
     pdl_id: str = Path(..., description="PDL ID (UUID)", openapi_examples={"example_uuid": {"summary": "Example UUID", "value": "550e8400-e29b-41d4-a716-446655440000"}}),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db)
 ) -> APIResponse:
     """Delete a PDL"""
@@ -384,7 +384,7 @@ async def delete_pdl(
 async def update_pdl_name(
     pdl_id: str = Path(..., description="PDL ID (UUID)", openapi_examples={"example_uuid": {"summary": "Example UUID", "value": "550e8400-e29b-41d4-a716-446655440000"}}),
     name_data: PDLUpdateName = Body(..., openapi_examples={"update_name": {"summary": "Update name", "value": {"name": "Nouveau nom de compteur"}}}),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Update PDL custom name"""
@@ -417,7 +417,7 @@ async def update_pdl_type(
         "production_only": {"summary": "Production only", "value": {"has_consumption": False, "has_production": True}},
         "both": {"summary": "Both consumption and production", "value": {"has_consumption": True, "has_production": True}}
     }),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Update PDL type (consumption and/or production)"""
@@ -451,7 +451,7 @@ async def toggle_pdl_active(
         "activate": {"summary": "Activate PDL", "value": {"is_active": True}},
         "deactivate": {"summary": "Deactivate PDL", "value": {"is_active": False}}
     }),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Toggle PDL active/inactive status"""
@@ -487,7 +487,7 @@ async def update_pdl_pricing_option(
         "hc_weekend": {"summary": "HC Nuit & Week-end", "value": {"pricing_option": "HC_WEEKEND"}},
         "clear": {"summary": "Remove pricing option", "value": {"pricing_option": None}}
     }),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """
@@ -539,7 +539,7 @@ async def update_pdl_selected_offer(
         "select_offer": {"summary": "Select an energy offer", "value": {"selected_offer_id": "550e8400-e29b-41d4-a716-446655440001"}},
         "clear": {"summary": "Remove selected offer", "value": {"selected_offer_id": None}}
     }),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """
@@ -608,7 +608,7 @@ async def link_production_pdl(
         "link": {"summary": "Link to production PDL", "value": {"linked_production_pdl_id": "550e8400-e29b-41d4-a716-446655440001"}},
         "unlink": {"summary": "Unlink production PDL", "value": {"linked_production_pdl_id": None}}
     }),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """
@@ -723,7 +723,7 @@ async def update_pdl_contract(
             }
         }
     ),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Update PDL contract information (subscribed power and offpeak hours)"""
@@ -770,7 +770,7 @@ async def reorder_pdls(
             }
         }
     ),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_not_demo),
     db: AsyncSession = Depends(get_db),
 ) -> APIResponse:
     """Update display order for multiple PDLs"""


### PR DESCRIPTION
## Summary
Implement read-only mode for the demo account by adding a centralized middleware dependency that blocks all write operations while preserving full read access.

## Changes
- Add `require_not_demo` middleware dependency to enforce demo account restrictions
- Apply to all write endpoints in PDL management, contributions, and account operations
- Demo account receives HTTP 403 with "Le compte de démonstration est en lecture seule" message

## Testing
- Demo account can perform all GET/read operations
- Demo account is blocked from write operations (POST, PUT, PATCH, DELETE)
- Existing accounts continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)