### PR TITLE
fix(ha-ws): correct cumulative sum handling on incremental import

### DIFF
--- a/apps/api/src/services/exporters/home_assistant.py
+++ b/apps/api/src/services/exporters/home_assistant.py
@@ -1826,6 +1826,7 @@ class HomeAssistantExporter(BaseExporter):
                 # Extract last date for each statistic
                 result_data = response.get("result", {})
                 last_dates: dict[str, datetime] = {}
+                last_sums: dict[str, float] = {}
 
                 for stat_id, entries in result_data.items():
                     if entries and isinstance(entries, list):
@@ -1834,16 +1835,28 @@ class HomeAssistantExporter(BaseExporter):
                         # The "start" field contains the timestamp
                         start_ts = last_entry.get("start")
                         if start_ts:
-                            # Parse ISO format timestamp
+                            # Parse timestamp — HA `recorder/statistics_during_period`
+                            # returns `start` as a numeric epoch in MILLISECONDS (since
+                            # HA core 2023+), not seconds. Auto-detect: any value > 1e12
+                            # is treated as ms (safe until year ~33658 in seconds).
                             if isinstance(start_ts, (int, float)):
-                                # Unix timestamp in seconds
-                                last_dates[stat_id] = datetime.fromtimestamp(start_ts, tz=tz_paris)
+                                ts = start_ts / 1000 if start_ts > 1e12 else start_ts
+                                last_dates[stat_id] = datetime.fromtimestamp(ts, tz=tz_paris)
                             else:
                                 # ISO format string
                                 try:
                                     last_dates[stat_id] = datetime.fromisoformat(str(start_ts).replace("Z", "+00:00"))
                                 except ValueError:
                                     logger.warning(f"[HA-WS] Could not parse timestamp for {stat_id}: {start_ts}")
+
+                        # Extract last sum so callers can continue the cumulative
+                        # series instead of restarting from 0 in incremental mode.
+                        sum_v = last_entry.get("sum")
+                        if sum_v is not None:
+                            try:
+                                last_sums[stat_id] = float(sum_v)
+                            except (TypeError, ValueError):
+                                logger.warning(f"[HA-WS] Could not parse sum for {stat_id}: {sum_v}")
 
                 # Find the oldest "last date" - this is where we need to start the incremental import
                 oldest_date = min(last_dates.values()) if last_dates else None
@@ -1857,6 +1870,7 @@ class HomeAssistantExporter(BaseExporter):
                     "success": True,
                     "message": f"Dernières dates récupérées pour {len(last_dates)} statistiques",
                     "last_dates": {k: v.isoformat() for k, v in last_dates.items()},
+                    "last_sums": last_sums,
                     "oldest_date": oldest_date.isoformat() if oldest_date else None,
                 }
 
@@ -1866,6 +1880,7 @@ class HomeAssistantExporter(BaseExporter):
                 "success": False,
                 "message": f"Erreur: {str(e)}",
                 "last_dates": {},
+                "last_sums": {},
                 "oldest_date": None,
             }
 
@@ -1985,14 +2000,21 @@ class HomeAssistantExporter(BaseExporter):
 
         prefix = self.config.get("statistic_id_prefix", "myelectricaldata")
 
-        # For incremental mode, get the last imported date
+        # For incremental mode, get the last imported date AND the last sums
+        # so the new exported records continue the existing cumulative series
+        # in HA instead of restarting at 0 (which causes giant negative deltas
+        # in the Energy dashboard).
         since_date: datetime | None = None
+        last_sums_raw: dict[str, float] = {}
+        last_dates_raw: dict[str, str] = {}
         if incremental:
             last_dates_result = await self.get_last_statistic_dates()
             if last_dates_result.get("success") and last_dates_result.get("oldest_date"):
                 from datetime import datetime
                 oldest_date_str = last_dates_result["oldest_date"]
                 since_date = datetime.fromisoformat(oldest_date_str)
+                last_sums_raw = last_dates_result.get("last_sums", {}) or {}
+                last_dates_raw = last_dates_result.get("last_dates", {}) or {}
                 logger.info(f"[HA-WS] Incremental mode: importing data since {since_date}")
             else:
                 # No existing data, fall back to full import
@@ -2051,9 +2073,23 @@ class HomeAssistantExporter(BaseExporter):
                 mode_str = "incremental" if incremental else "full"
                 logger.info(f"[HA-WS] Processing {len(usage_point_ids)} PDLs ({mode_str} mode): {usage_point_ids}")
                 for pdl in usage_point_ids:
+                    # Build per-PDL state (sums + last dates) — last dates are
+                    # critical to avoid double-counting in incremental mode.
+                    (
+                        init_consumption_sums,
+                        init_cost_sums,
+                        init_production_sum,
+                        last_dates_consumption,
+                        last_date_production,
+                    ) = self._extract_per_pdl_state(prefix, pdl, last_sums_raw, last_dates_raw)
+
                     # Get consumption data by tariff
                     logger.info(f"[HA-WS] Getting consumption data for PDL {pdl}" + (f" (since {since_date})" if since_date else ""))
-                    consumption_by_tariff = await self._get_consumption_statistics_by_tariff(db, pdl, since_date)
+                    consumption_by_tariff = await self._get_consumption_statistics_by_tariff(
+                        db, pdl, since_date,
+                        initial_sums=init_consumption_sums,
+                        last_dates_by_tariff=last_dates_consumption,
+                    )
                     logger.info(f"[HA-WS] Got {len(consumption_by_tariff)} tariff buckets for {pdl}: {list(consumption_by_tariff.keys())}")
 
                     for tariff_tag, stats in consumption_by_tariff.items():
@@ -2085,7 +2121,9 @@ class HomeAssistantExporter(BaseExporter):
 
                     # Get cost data from consumption and energy offer prices
                     logger.info(f"[HA-WS] Calculating costs for PDL {pdl}")
-                    cost_by_tariff = await self._get_cost_statistics_by_tariff(db, pdl, consumption_by_tariff)
+                    cost_by_tariff = await self._get_cost_statistics_by_tariff(
+                        db, pdl, consumption_by_tariff, initial_sums=init_cost_sums
+                    )
 
                     for tariff_tag, cost_stats in cost_by_tariff.items():
                         # Import même si cost_stats est vide pour créer l'entité dans HA
@@ -2116,7 +2154,11 @@ class HomeAssistantExporter(BaseExporter):
 
                     # Get production data (production has no tariff distinction)
                     # Import même si vide pour créer l'entité dans HA
-                    production_stats = await self._get_production_statistics(db, pdl, since_date)
+                    production_stats = await self._get_production_statistics(
+                        db, pdl, since_date,
+                        initial_sum=init_production_sum,
+                        last_date=last_date_production,
+                    )
                     statistic_id = f"{prefix}:production_{pdl}"
 
                     # Import in chunks to avoid WebSocket timeout
@@ -2211,14 +2253,20 @@ class HomeAssistantExporter(BaseExporter):
                     "production": production,
                 })
 
-        # For incremental mode, get the last imported date
+        # For incremental mode, get the last imported date AND last sums + last
+        # dates per stat for cumulative continuity AND per-tariff filtering.
+        # See import_statistics for the full rationale.
         since_date: datetime | None = None
+        last_sums_raw: dict[str, float] = {}
+        last_dates_raw: dict[str, str] = {}
         if incremental:
             last_dates_result = await self.get_last_statistic_dates()
             if last_dates_result.get("success") and last_dates_result.get("oldest_date"):
                 from datetime import datetime as dt
                 oldest_date_str = last_dates_result["oldest_date"]
                 since_date = dt.fromisoformat(oldest_date_str)
+                last_sums_raw = last_dates_result.get("last_sums", {}) or {}
+                last_dates_raw = last_dates_result.get("last_dates", {}) or {}
                 logger.info(f"[HA-WS] Incremental mode: importing data since {since_date}")
             else:
                 # No existing data, fall back to full import
@@ -2287,13 +2335,27 @@ class HomeAssistantExporter(BaseExporter):
                 }
 
                 for pdl_idx, pdl in enumerate(usage_point_ids):
+                    # Build per-PDL state (sums + last dates) — last dates are
+                    # critical to avoid double-counting in incremental mode.
+                    (
+                        init_consumption_sums,
+                        init_cost_sums,
+                        init_production_sum,
+                        last_dates_consumption,
+                        last_date_production,
+                    ) = self._extract_per_pdl_state(prefix, pdl, last_sums_raw, last_dates_raw)
+
                     # Étape: Lecture des données de consommation
                     await emit_progress(
                         current_step, total_steps,
                         f"PDL {pdl_idx + 1}/{num_pdls}: Lecture consommation...",
                         results["consumption"], results["cost"], results["production"]
                     )
-                    consumption_by_tariff = await self._get_consumption_statistics_by_tariff(db, pdl, since_date)
+                    consumption_by_tariff = await self._get_consumption_statistics_by_tariff(
+                        db, pdl, since_date,
+                        initial_sums=init_consumption_sums,
+                        last_dates_by_tariff=last_dates_consumption,
+                    )
                     current_step += 1
 
                     # Import consommation par tarif
@@ -2331,7 +2393,9 @@ class HomeAssistantExporter(BaseExporter):
                         f"PDL {pdl_idx + 1}/{num_pdls}: Calcul des coûts...",
                         results["consumption"], results["cost"], results["production"]
                     )
-                    cost_by_tariff = await self._get_cost_statistics_by_tariff(db, pdl, consumption_by_tariff)
+                    cost_by_tariff = await self._get_cost_statistics_by_tariff(
+                        db, pdl, consumption_by_tariff, initial_sums=init_cost_sums
+                    )
                     current_step += 1
 
                     for tariff_tag, cost_stats in cost_by_tariff.items():
@@ -2368,7 +2432,11 @@ class HomeAssistantExporter(BaseExporter):
                         f"PDL {pdl_idx + 1}/{num_pdls}: Import production...",
                         results["consumption"], results["cost"], results["production"]
                     )
-                    production_stats = await self._get_production_statistics(db, pdl, since_date)
+                    production_stats = await self._get_production_statistics(
+                        db, pdl, since_date,
+                        initial_sum=init_production_sum,
+                        last_date=last_date_production,
+                    )
                     statistic_id = f"{prefix}:production_{pdl}"
                     imported, msg_id, chunk_errors = await self._import_stats_in_chunks(
                         ws,
@@ -2405,11 +2473,98 @@ class HomeAssistantExporter(BaseExporter):
                 **results,
             }
 
+    @staticmethod
+    def _extract_per_pdl_state(
+        prefix: str,
+        pdl: str,
+        last_sums_raw: dict[str, float],
+        last_dates_raw: dict[str, str],
+    ) -> tuple[
+        dict[str, float],
+        dict[str, float],
+        float,
+        dict[str, datetime],
+        datetime | None,
+    ]:
+        """Build per-PDL state (sums + last dates) from global maps.
+
+        Splits the flat {statistic_id: sum/date} maps (returned by
+        get_last_statistic_dates) into per-category buckets needed by the
+        3 export functions:
+        - consumption: per-tariff init sums + per-tariff last dates (filter)
+        - cost:        per-tariff init sums (no filter, derived from consumption)
+        - production:  single init sum + single last date (filter)
+
+        The per-tariff last_dates are crucial in incremental mode: the global
+        since_date used in the SQL fetch is the OLDEST across all stats, so
+        records ALREADY exported for individual tariffs (with newer last_dates)
+        would otherwise be re-processed and overwrite existing entries.
+
+        Args:
+            prefix: statistic_id prefix used by MED (e.g. "myelectricaldata")
+            pdl: usage point ID
+            last_sums_raw: flat map {statistic_id: last_sum}
+            last_dates_raw: flat map {statistic_id: last_date_isoformat}
+
+        Returns:
+            (
+                init_consumption_sums,
+                init_cost_sums,
+                init_production_sum,
+                last_dates_by_consumption_tariff,
+                last_date_production,
+            )
+        """
+        from datetime import datetime as _dt
+
+        consumption_prefix = f"{prefix}:consumption_{pdl}_"
+        cost_prefix = f"{prefix}:cost_{pdl}_"
+        production_id = f"{prefix}:production_{pdl}"
+
+        init_consumption: dict[str, float] = {}
+        init_cost: dict[str, float] = {}
+        init_production: float = 0.0
+        last_dates_consumption: dict[str, datetime] = {}
+        last_date_production: datetime | None = None
+
+        for stat_id, sum_v in last_sums_raw.items():
+            if stat_id.startswith(consumption_prefix):
+                tag = stat_id[len(consumption_prefix):]
+                init_consumption[tag] = sum_v
+            elif stat_id.startswith(cost_prefix):
+                tag = stat_id[len(cost_prefix):]
+                init_cost[tag] = sum_v
+            elif stat_id == production_id:
+                init_production = sum_v
+
+        for stat_id, date_str in last_dates_raw.items():
+            if not date_str:
+                continue
+            try:
+                parsed = _dt.fromisoformat(date_str)
+            except ValueError:
+                continue
+            if stat_id.startswith(consumption_prefix):
+                tag = stat_id[len(consumption_prefix):]
+                last_dates_consumption[tag] = parsed
+            elif stat_id == production_id:
+                last_date_production = parsed
+
+        return (
+            init_consumption,
+            init_cost,
+            init_production,
+            last_dates_consumption,
+            last_date_production,
+        )
+
     async def _get_consumption_statistics_by_tariff(
         self,
         db: AsyncSession,
         pdl: str,
         since_date: datetime | None = None,
+        initial_sums: dict[str, float] | None = None,
+        last_dates_by_tariff: dict[str, datetime] | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         """Get consumption statistics grouped by tariff type for Energy Dashboard
 
@@ -2422,13 +2577,26 @@ class HomeAssistantExporter(BaseExporter):
         Args:
             db: Database session
             pdl: Usage point ID
-            since_date: Only include records after this date (for incremental import)
+            since_date: Only include records after this date (for incremental import).
+                This is the GLOBAL oldest date across all tariffs — needed because
+                we fetch records per PDL, not per tariff.
+            initial_sums: Per-tariff starting sums (kWh) to seed the cumulative
+                series. Required in incremental mode so the exported sums continue
+                the existing history in HA — otherwise the sums restart at 0,
+                HA Energy sees a giant negative delta and the dashboard breaks.
+            last_dates_by_tariff: Per-tariff last date already in HA. When provided,
+                records whose hour is <= this date are SKIPPED for that tariff
+                (they are already exported). This prevents double-counting in
+                incremental mode where the global since_date is older than some
+                tariffs' last_date.
 
         Returns:
             Dict of tariff_tag -> list of statistics records
             Example: {"base": [...], "hc": [...], "hp": [...]}
             or for TEMPO: {"blue_hc": [...], "blue_hp": [...], "white_hc": [...], ...}
         """
+        initial_sums = initial_sums or {}
+        last_dates_by_tariff = last_dates_by_tariff or {}
         from datetime import timedelta
         from zoneinfo import ZoneInfo
 
@@ -2521,17 +2689,17 @@ class HomeAssistantExporter(BaseExporter):
                 for period in ["hc", "hp"]:
                     key = f"{color}_{period}"
                     stats_by_tariff[key] = []
-                    cumulative_by_tariff[key] = 0.0
+                    cumulative_by_tariff[key] = initial_sums.get(key, 0.0)
         elif pricing_option in ("HC/HP", "HCHP", "EJP"):
             # 2 buckets: hc, hp
             stats_by_tariff["hc"] = []
             stats_by_tariff["hp"] = []
-            cumulative_by_tariff["hc"] = 0.0
-            cumulative_by_tariff["hp"] = 0.0
+            cumulative_by_tariff["hc"] = initial_sums.get("hc", 0.0)
+            cumulative_by_tariff["hp"] = initial_sums.get("hp", 0.0)
         else:
             # BASE: 1 bucket
             stats_by_tariff["base"] = []
-            cumulative_by_tariff["base"] = 0.0
+            cumulative_by_tariff["base"] = initial_sums.get("base", 0.0)
 
         # 5. Helper to determine if an hour is in off-peak period
         def is_offpeak_hour(hour: int, minute: int = 0) -> bool:
@@ -2680,10 +2848,19 @@ class HomeAssistantExporter(BaseExporter):
             start_dt = datetime.combine(record_date, datetime.min.time().replace(hour=hour, minute=0, second=0))
             start_dt = start_dt.replace(tzinfo=tz_paris)
 
+            # Skip records already exported to HA for THIS specific tariff.
+            # The global since_date is the OLDEST among all tariffs (so the SQL
+            # fetch is wide enough to catch every tariff's new records), but each
+            # individual tariff has its own last_date — we must skip records
+            # that are <= that tariff's last_date to avoid double-counting.
+            tariff_last_date = last_dates_by_tariff.get(tariff_tag)
+            if tariff_last_date is not None and start_dt <= tariff_last_date:
+                continue
+
             # Ensure bucket exists (safety)
             if tariff_tag not in stats_by_tariff:
                 stats_by_tariff[tariff_tag] = []
-                cumulative_by_tariff[tariff_tag] = 0.0
+                cumulative_by_tariff[tariff_tag] = initial_sums.get(tariff_tag, 0.0)
 
             # Update cumulative and add stat
             cumulative_by_tariff[tariff_tag] += value_kwh
@@ -2706,6 +2883,7 @@ class HomeAssistantExporter(BaseExporter):
         db: AsyncSession,
         pdl: str,
         consumption_by_tariff: dict[str, list[dict[str, Any]]],
+        initial_sums: dict[str, float] | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         """Calculate cost statistics from consumption data and energy offer prices
 
@@ -2716,11 +2894,15 @@ class HomeAssistantExporter(BaseExporter):
             db: Database session
             pdl: Usage point ID
             consumption_by_tariff: Consumption stats from _get_consumption_statistics_by_tariff()
+            initial_sums: Per-tariff starting sums (EUR) to seed the cumulative
+                cost series. Required in incremental mode for the same reason
+                as _get_consumption_statistics_by_tariff (sum continuity).
 
         Returns:
             Dict of tariff_tag -> list of cost statistics in EUR
             Example: {"blue_hc": [{start, state, sum}, ...], ...}
         """
+        initial_sums = initial_sums or {}
 
         from ...models.energy_provider import EnergyOffer
         from ...models.pdl import PDL
@@ -2790,7 +2972,7 @@ class HomeAssistantExporter(BaseExporter):
 
             price_per_kwh = prices[tariff_tag]
             cost_stats = []
-            cumulative_cost = 0.0
+            cumulative_cost = initial_sums.get(tariff_tag, 0.0)
 
             for stat in consumption_stats:
                 # stat has: start, state (kWh for this period), sum (cumulative kWh)
@@ -2814,6 +2996,8 @@ class HomeAssistantExporter(BaseExporter):
         db: AsyncSession,
         pdl: str,
         since_date: datetime | None = None,
+        initial_sum: float = 0.0,
+        last_date: datetime | None = None,
     ) -> list[dict[str, Any]]:
         """Get production statistics for Energy Dashboard
 
@@ -2824,6 +3008,11 @@ class HomeAssistantExporter(BaseExporter):
             db: Database session
             pdl: Usage point ID
             since_date: Only include records after this date (for incremental import)
+            initial_sum: Starting sum (kWh) to seed the cumulative production
+                series. Required in incremental mode for sum continuity.
+            last_date: Production-specific last date already in HA. Records whose
+                hour is <= this date are skipped (already exported). Same anti
+                double-counting logic as _get_consumption_statistics_by_tariff.
 
         Returns:
             List of statistics records [{start, state, sum}, ...]
@@ -2926,8 +3115,18 @@ class HomeAssistantExporter(BaseExporter):
 
         # Build final statistics sorted by time
         stats = []
-        cumulative_kwh = 0.0
+        cumulative_kwh = initial_sum
         sorted_keys = sorted(hourly_aggregation.keys(), key=lambda k: (k[0], k[1]))
+
+        # If a last_date is provided, skip every record at or before it (already
+        # in HA — same anti double-counting logic as the consumption builder).
+        if last_date is not None:
+            from zoneinfo import ZoneInfo as _ZI
+            _tz = _ZI("Europe/Paris")
+            def _skip(rd, h):
+                start = datetime.combine(rd, datetime.min.time().replace(hour=h, minute=0, second=0))
+                return start.replace(tzinfo=_tz) <= last_date
+            sorted_keys = [k for k in sorted_keys if not _skip(k[0], k[1])]
 
         for record_date, hour in sorted_keys:
             value_kwh = hourly_aggregation[(record_date, hour)]


### PR DESCRIPTION
## Summary

The HA WebSocket exporter (`recorder/import_statistics`) has 3 distinct bugs that together break the Energy dashboard for users running incremental imports. They compound: each one masks the next.

This PR fixes all three with a single localized change to `home_assistant.py`.

## Bug 1: HA timestamps are milliseconds, not seconds

`get_last_statistic_dates` parses the `start` field of `recorder/statistics_during_period` responses with `datetime.fromtimestamp(start_ts)` — but HA core 2023+ returns these timestamps as a numeric epoch in **milliseconds**, not seconds.

**Effect**: `OverflowError: year 58244 is out of range`. The function falls through to the bare `except`, returns `success: False`, and the caller silently falls back to a full re-import on every scheduled run.

**Fix**: auto-detect ms vs s by magnitude (`start_ts > 1e12 → ms`). Safe until ~year 33658 in seconds.

## Bug 2: Cumulative sums restart at 0 in incremental mode

`_get_consumption_statistics_by_tariff`, `_get_cost_statistics_by_tariff` and `_get_production_statistics` initialize their cumulative accumulators to `0.0` unconditionally. In full mode this is correct. In incremental mode, the new sums clobber the existing monotonic series in HA — the Energy dashboard sees a giant negative delta on the boundary hour (e.g. **-11705 kWh on TEMPO blue_hp at the season transition**) and stops displaying anything sensible.

**Fix**:
- `get_last_statistic_dates` now also returns `last_sums` (extracted from the same `statistics_during_period` response, no extra round-trip).
- A new helper `_extract_per_pdl_state` splits the flat `{statistic_id: sum/date}` maps into per-category buckets needed by the 3 export functions.
- The 3 builders accept `initial_sums` (or `initial_sum` for production) and seed their cumulative accumulators with those values instead of `0.0`.

## Bug 3: Per-tariff records re-processed and double-counted

After fixing bug 2, the cumulative continuity worked but **each new MED run shifted the series upward by the consumption delta between the global `oldest_date` and each tariff's own `last_date`**.

Root cause: incremental mode uses ONE global `since_date` (the oldest across all tariffs) for the SQL fetch. But each individual tariff has its own newer `last_date` — and the previous code re-iterated all fetched records, re-importing entries that were already in HA and overwriting their sums with shifted-up values. After enough runs, totals are 2-3x the real value.

**Fix**: pass `last_dates_by_tariff` (and `last_date` for production) to the builders, and skip records whose timestamp is `<= last_date` for that tariff. The SQL fetch stays wide (global oldest) so every tariff still sees its new records, but per-tariff filtering inside the loop prevents re-processing.

Cost statistics inherit the filter for free since they're derived from the (already filtered) `consumption_by_tariff`.

## Effect

In incremental mode, MED now correctly:

- Reads existing sums from HA and uses them as cumulative starting points
- Skips records that are already exported (per tariff)
- Only ADDS strictly new records on top of the existing series
- The sum stays monotonic, no compensation event in HA Energy

## Test plan

Verified locally on a TEMPO production setup running for 26 months:

- [x] After the fix, no `year 58244` error in MED logs (was happening every 30 min)
- [x] After the fix, MED reports `Found last dates for 12/13 statistics` and runs in **incremental** mode (not full-import on loop)
- [x] After the fix, sums stay monotonic across all 4 season-transition days (2026-03-31, 2026-04-01, 2026-04-03)
- [x] After the fix, the 12-month rolling total in HA Energy matches actual consumption (~10 MWh/year vs ~21 MWh that the bugs were producing)
- [x] After the fix, repeated incremental runs do not shift existing entries (verified by querying the recorder DB directly between runs)
- [x] Compose-build the patched container, confirm Python startup is clean

Note: this PR only contains the code fix. Existing users whose recorder DB was already corrupted by the bugs will need a one-shot data repair (purge `med:*` stats from HA recorder and let MED full-reimport). A separate runbook can be added if needed.
